### PR TITLE
Fix compilation issues on zOS (#1639)

### DIFF
--- a/compiler/runtime/Helpers.inc
+++ b/compiler/runtime/Helpers.inc
@@ -1,25 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corp. and others
- *
- * This program and the accompanying materials are made available under
- * the terms of the Eclipse Public License 2.0 which accompanies this
- * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
- * or the Apache License, Version 2.0 which accompanies this distribution and
- * is available at https://www.apache.org/licenses/LICENSE-2.0.
- *
- * This Source Code may also be made available under the following
- * Secondary Licenses when the conditions for such availability set
- * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
- * General Public License, version 2 with the GNU Classpath
- * Exception [1] and GNU General Public License, version 2 with the
- * OpenJDK Assembly Exception [2].
- *
- * [1] https://www.gnu.org/software/classpath/license.html
- * [2] http://openjdk.java.net/legal/assembly-exception.html
- *
- * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
- *******************************************************************************/
-
 SETVAL(TR_arrayBoundsCheck,1)
 SETVAL(TR_icallVMprJavaSendStatic0,TR_arrayBoundsCheck+1)
 SETVAL(TR_icallVMprJavaSendStatic1,TR_arrayBoundsCheck+2)


### PR DESCRIPTION
m4 on zOS can not handle C/C++ style comments. This file is included in
a C++ header and a few m4 files so the copyright header needs to work
for both. Remove the copyright header while a solution is being found.

zOS assembler can not handle lines with more than 71 characters even in
comments. When a solution is found ensure that the length of each line
in the copyright header is a maximum of 71 characters.

[ci skip] since this is just removing a copyright header

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>