### PR TITLE
Revert part of fix incorrect usage of TR::Options

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -326,7 +326,7 @@ OMR::Compilation::Compilation(
    // while the PersistentMethodInfo is allocated during codegen creation
    // Access to this list must be performed with assumptionTableMutex in hand
    //
-   if (!options.getOption(TR_DisableFastAssumptionReclamation))
+   if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableFastAssumptionReclamation))
       _metadataAssumptionList = new (m->trPersistentMemory()) TR::SentinelRuntimeAssumption();
 #endif
 
@@ -916,7 +916,7 @@ int32_t OMR::Compilation::compile()
    if (!self()->getOption(TR_DisableSupportForCpuSpentInCompilation))
       _cpuTimeAtStartOfCompilation = TR::Compiler->vm.cpuTimeSpentInCompilationThread(self());
 
-   bool printCodegenTime = self()->getOption(TR_CummTiming);
+   bool printCodegenTime = TR::Options::getCmdLineOptions()->getOption(TR_CummTiming);
 
    if (self()->isOptServer())
       {
@@ -924,7 +924,7 @@ int32_t OMR::Compilation::compile()
       if( (self()->getMethodHotness() <= warm))
          {
          if (!TR::Compiler->target.cpu.isPower())
-            self()->getOptions()->setOption(TR_DisableInternalPointers);
+            TR::Options::getCmdLineOptions()->setOption(TR_DisableInternalPointers);
          }
       self()->getOptions()->setOption(TR_DisablePartialInlining);
       }
@@ -1841,7 +1841,7 @@ void OMR::Compilation::resetVisitCounts(vcount_t count, TR::TreeTop *start)
 void OMR::Compilation::reportFailure(const char *reason)
    {
    traceMsg(self(), "Compilation Failed Because: %s\n", reason);
-   if (self()->getOption(TR_PrintErrorInfoOnCompFailure))
+   if (TR::Options::getCmdLineOptions()->getOption(TR_PrintErrorInfoOnCompFailure))
       fprintf(stderr, "Compilation Failed Because: %s\n", reason);
    }
 

--- a/compiler/control/CompileMethod.cpp
+++ b/compiler/control/CompileMethod.cpp
@@ -405,15 +405,15 @@ compileMethodFromDetails(
             }
 
          if (
-               compiler.getOption(TR_PerfTool) 
-            || compiler.getOption(TR_EmitExecutableELFFile)
-            || compiler.getOption(TR_EmitRelocatableELFFile)
+               TR::Options::getCmdLineOptions()->getOption(TR_PerfTool) 
+            || TR::Options::getCmdLineOptions()->getOption(TR_EmitExecutableELFFile)
+            || TR::Options::getCmdLineOptions()->getOption(TR_EmitRelocatableELFFile)
             )
             {
             TR::CodeCacheManager &codeCacheManager(fe.codeCacheManager());
             TR::CodeGenerator &codeGenerator(*compiler.cg());
             codeCacheManager.registerCompiledMethod(compiler.externalName(), startPC, codeGenerator.getCodeLength());
-            if (compiler.getOption(TR_EmitRelocatableELFFile))
+            if (TR::Options::getCmdLineOptions()->getOption(TR_EmitRelocatableELFFile))
                {
                auto &relocations = codeGenerator.getStaticRelocations();
                for (auto it = relocations.begin(); it != relocations.end(); ++it)
@@ -421,7 +421,7 @@ compileMethodFromDetails(
                   codeCacheManager.registerStaticRelocation(*it);
                   }
                }
-            if (compiler.getOption(TR_PerfTool))
+            if (TR::Options::getCmdLineOptions()->getOption(TR_PerfTool))
                {
                generatePerfToolEntry(startPC, codeGenerator.getCodeEnd(), compiler.signature(), compiler.getHotnessName(compiler.getMethodHotness()));
                }

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -156,7 +156,7 @@ OMR::SymbolReference::getUseonlyAliasesBV(TR::SymbolReferenceTable * symRefTab)
       case TR::Symbol::IsResolvedMethod:
          {
          TR::ResolvedMethodSymbol * resolvedMethodSymbol = _symbol->castToResolvedMethodSymbol();
-         if (!TR::comp()->getOption(TR_EnableHCR))
+         if (!TR::Options::getCmdLineOptions()->getOption(TR_EnableHCR))
             {
             switch (resolvedMethodSymbol->getRecognizedMethod())
                {
@@ -354,7 +354,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
          {
          TR::ResolvedMethodSymbol * resolvedMethodSymbol = _symbol->castToResolvedMethodSymbol();
 
-         if (!comp->getOption(TR_EnableHCR))
+         if (!TR::Options::getCmdLineOptions()->getOption(TR_EnableHCR))
             {
             switch (resolvedMethodSymbol->getRecognizedMethod())
                {

--- a/compiler/optimizer/Inliner.hpp
+++ b/compiler/optimizer/Inliner.hpp
@@ -586,7 +586,7 @@ class OMR_InlinerPolicy : public TR::OptimizationPolicy, public OMR_InlinerHelpe
       virtual int32_t getInitialBytecodeSize(TR_ResolvedMethod *feMethod, TR::ResolvedMethodSymbol * methodSymbol, TR::Compilation *comp);
       virtual bool tryToInline(TR_CallTarget *, TR_CallStack *, bool);
       virtual bool inlineMethodEvenForColdBlocks(TR_ResolvedMethod *method);
-      bool aggressiveSmallAppOpts() { return comp()->getOption(TR_AggressiveOpts); }
+      bool aggressiveSmallAppOpts() { return TR::Options::getCmdLineOptions()->getOption(TR_AggressiveOpts); }
       virtual bool willBeInlinedInCodeGen(TR::RecognizedMethod method);
       virtual bool canInlineMethodWhileInstrumenting(TR_ResolvedMethod *method);
 

--- a/compiler/optimizer/LoopVersioner.cpp
+++ b/compiler/optimizer/LoopVersioner.cpp
@@ -200,7 +200,7 @@ bool TR_LoopVersioner::loopIsWorthVersioning(TR_RegionStructure *naturalLoop)
       }
 
    // if aggressive loop versioner flag is set then run at any optlevel, otherwise only at warm or less
-   bool aggressive = comp()->getOption(TR_EnableAggressiveLoopVersioning);
+   bool aggressive = TR::Options::getCmdLineOptions()->getOption(TR_EnableAggressiveLoopVersioning);
    if (aggressive || comp()->getMethodHotness() <= warm)
       {
       if (naturalLoop->getParent())
@@ -225,7 +225,7 @@ bool TR_LoopVersioner::loopIsWorthVersioning(TR_RegionStructure *naturalLoop)
             }
          }
 
-      bool aggressive = comp()->getOption(TR_EnableAggressiveLoopVersioning);
+      bool aggressive = TR::Options::getCmdLineOptions()->getOption(TR_EnableAggressiveLoopVersioning);
 
       int32_t lvBlockFreqCutoff;
       static const char * b = feGetEnv("TR_LoopVersionerFreqCutoff");
@@ -567,7 +567,7 @@ int32_t TR_LoopVersioner::performWithoutDominators()
          {
          // default hotness threshold
          TR_Hotness hotnessThreshold = hot;
-         if (comp()->getOption(TR_EnableAggressiveLoopVersioning))
+         if (TR::Options::getCmdLineOptions()->getOption(TR_EnableAggressiveLoopVersioning))
             {
             if (trace()) traceMsg(comp(), "aggressiveLoopVersioning: raising hotnessThreshold for conditionalsWillBeEliminated\n");
             hotnessThreshold = maxHotness; // threshold which can't be matched by the > operator
@@ -712,7 +712,7 @@ int32_t TR_LoopVersioner::performWithoutDominators()
    ////if (!_virtualGuardPairs.isEmpty())
    if (!_virtualGuardInfo.isEmpty())
       {
-      bool disableLT = comp()->getOption(TR_DisableLoopTransfer);
+      bool disableLT = TR::Options::getCmdLineOptions()->getOption(TR_DisableLoopTransfer);
       if (!disableLT)
          performLoopTransfer();
       }
@@ -3252,7 +3252,7 @@ bool TR_LoopVersioner::detectChecksToBeEliminated(TR_RegionStructure *whileLoop,
             )
             {
             isUnimportant = true;
-            if (trace() || comp()->getOption(TR_CountOptTransformations))
+            if (trace() || TR::Options::getCmdLineOptions()->getOption(TR_CountOptTransformations))
                {
                for (TR::TreeTop *tt = entryTree; isUnimportant && tt != exitTree; tt = tt->getNextTreeTop())
                   {
@@ -3315,7 +3315,7 @@ bool TR_LoopVersioner::detectChecksToBeEliminated(TR_RegionStructure *whileLoop,
          vcount_t visitCount = comp()->incVisitCount(); //@TODO: unsafe API/use pattern
          updateDefinitionsAndCollectProfiledExprs(NULL, currentNode, visitCount, specializedInvariantNodes, invariantNodes, invariantTranslationNodesList, NULL, collectProfiledExprs, nextBlock, warmBranchCount);
 
-         bool disableLT = comp()->getOption(TR_DisableLoopTransfer);
+         bool disableLT = TR::Options::getCmdLineOptions()->getOption(TR_DisableLoopTransfer);
          if (!disableLT &&
              currentNode->isTheVirtualGuardForAGuardedInlinedCall() &&
              blocksInWhileLoop.find(currentNode->getBranchDestination()->getNode()->getBlock()))
@@ -3791,7 +3791,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
          }
 
       TR::Node *lastTree = nextBlock->getLastRealTreeTop()->getNode();
-      bool disableLT = comp()->getOption(TR_DisableLoopTransfer);
+      bool disableLT = TR::Options::getCmdLineOptions()->getOption(TR_DisableLoopTransfer);
       if (!disableLT &&
           lastTree->getOpCode().isIf() &&
           blocksInWhileLoop.find(lastTree->getBranchDestination()->getNode()->getBlock()) &&
@@ -4255,7 +4255,7 @@ void TR_LoopVersioner::versionNaturalLoop(TR_RegionStructure *whileLoop, List<TR
    TR_Hotness hotnessThreshold = hot;
 
    // If aggressive loop versioning is requested, don't call buildNullCheckComparisonsTree based on hotness
-   if (comp()->getOption(TR_EnableAggressiveLoopVersioning))
+   if (TR::Options::getCmdLineOptions()->getOption(TR_EnableAggressiveLoopVersioning))
       {
       if (trace()) traceMsg(comp(), "aggressiveLoopVersioning: raising hotnessThreshold for buildNullCheckComparisonsTree\n");
       hotnessThreshold = maxHotness; // threshold which can't be matched by the > operator

--- a/compiler/optimizer/OMROptimizer.cpp
+++ b/compiler/optimizer/OMROptimizer.cpp
@@ -1139,7 +1139,7 @@ void OMR::Optimizer::optimize()
          }
       }
 
-   if (comp()->getOption(TR_EnableDeterministicOrientedCompilation) &&
+   if (TR::Options::getCmdLineOptions()->getOption(TR_EnableDeterministicOrientedCompilation) &&
        comp()->isOutermostMethod() &&
        (comp()->getMethodHotness() > cold) &&
        (comp()->getMethodHotness() < scorching))
@@ -1353,13 +1353,13 @@ int32_t OMR::Optimizer::performOptimization(const OptimizationStrategy *optimiza
 #ifdef J9_PROJECT_SPECIFIC
       case IfNotClassLoadPhase:
          if (!comp()->getPersistentInfo()->isClassLoadingPhase() ||
-             comp()->getOption(TR_DontDowngradeToCold))
+             TR::Options::getCmdLineOptions()->getOption(TR_DontDowngradeToCold))
             doThisOptimization = true;
          break;
 
       case IfNotClassLoadPhaseAndNotProfiling:
          if ((!comp()->getPersistentInfo()->isClassLoadingPhase() ||
-              comp()->getOption(TR_DontDowngradeToCold))
+              TR::Options::getCmdLineOptions()->getOption(TR_DontDowngradeToCold))
                &&
              (!comp()->isProfilingCompilation() || debug("ignoreIfNotProfiling"))
             )

--- a/compiler/optimizer/OrderBlocks.cpp
+++ b/compiler/optimizer/OrderBlocks.cpp
@@ -480,7 +480,7 @@ bool TR_OrderBlocks::candidateIsBetterSuccessorThanBest(TR::CFGEdge *candidateEd
 
    //if (!_superColdBlockOnly)
    //   {
-      if (!comp()->getOption(TR_DisableInterpreterProfiling))
+      if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableInterpreterProfiling))
          {
          if (candidateEdge->getFrequency() >= 0)
             {

--- a/compiler/optimizer/VPHandlers.cpp
+++ b/compiler/optimizer/VPHandlers.cpp
@@ -12771,7 +12771,7 @@ TR::Node *constrainArrayStoreChk(OMR::ValuePropagation *vp, TR::Node *node)
                   }
 
               else if ( !vp->comp()->compileRelocatableCode() &&
-                        !(vp->comp()->getOption(TR_DisableArrayStoreCheckOpts))  &&
+                        !(TR::Options::getCmdLineOptions()->getOption(TR_DisableArrayStoreCheckOpts))  &&
                         arrayComponentClass &&
                         objectClass  &&
                         vp->fe()->isInstanceOf(objectClass, arrayComponentClass,true,true)

--- a/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
+++ b/compiler/x/amd64/codegen/AMD64SystemLinkage.cpp
@@ -892,7 +892,7 @@ TR::Register *TR::AMD64SystemLinkage::buildDirectDispatch(
          methodSymRef,
          cg());
 
-      if (comp()->getOption(TR_EmitRelocatableELFFile))
+      if (TR::Options::getCmdLineOptions()->getOption(TR_EmitRelocatableELFFile))
          {
          LoadRegisterInstruction->setReloKind(TR_NativeMethodAbsolute);
          }


### PR DESCRIPTION
- Backing out this commit because of 2% performance regression on daytrader

Signed-off-by: Harry Yu <harryyu1994@gmail.com>