### PR TITLE
Fix file handle leak in isRunningInContainer() function

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -4259,6 +4259,7 @@ static int32_t
 isRunningInContainer(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer)
 {
 	int32_t rc = 0;
+	FILE *cgroupFile = NULL;
 
 	/* Assume we are not in container */
 	*inContainer = FALSE;
@@ -4269,7 +4270,7 @@ isRunningInContainer(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer)
 		 * then the process is not running in a container.
 		 * For any other cgroup name, assume we are in a container.
 		 */
-		FILE *cgroupFile = fopen(OMR_PROC_PID_ONE_CGROUP_FILE, "r");
+		cgroupFile = fopen(OMR_PROC_PID_ONE_CGROUP_FILE, "r");
 
 		if (NULL == cgroupFile) {
 			int32_t osErrCode = errno;
@@ -4322,6 +4323,9 @@ isRunningInContainer(struct OMRPortLibrary *portLibrary, BOOLEAN *inContainer)
 	}
 	Trc_PRT_isRunningInContainer_container_detected((uintptr_t)*inContainer);
 _end:
+	if (NULL != cgroupFile) {
+		fclose(cgroupFile);
+	}
 	return rc;
 }
 


### PR DESCRIPTION
Close `cgroupFile` file handle at end of isRunningInContainer().

Signed-off-by: Ashutosh Mehra <asmehra1@in.ibm.com>