### PR TITLE
Do not version w.r.t. concurrently writable memory

### DIFF
--- a/compiler/optimizer/LoopVersioner.hpp
+++ b/compiler/optimizer/LoopVersioner.hpp
@@ -240,6 +240,8 @@ class TR_LoopVersioner : public TR_LoopTransformer
    bool buildLoopInvariantTree(List<TR::TreeTop> *, List<TR::TreeTop> *, List<TR::TreeTop> *, List<TR::TreeTop> *, List<TR::Node> *, List<TR_NodeParentSymRef> *, List<TR_NodeParentSymRefWeightTuple> *, TR::Block *, TR::Block *);
    void convertSpecializedLongsToInts(TR::Node *, vcount_t, TR::SymbolReference **);
    void collectAllExpressionsToBeChecked(List<TR::TreeTop> *, List<TR::TreeTop> *, List<TR::TreeTop> *, List<TR::TreeTop> *, TR::Node *, List<TR::Node> *, TR::Block *, vcount_t);
+   bool requiresPrivatization(TR::Node *);
+   bool suppressInvarianceAndPrivatization(TR::SymbolReference *);
 
    void updateDefinitionsAndCollectProfiledExprs(TR::Node *,TR::Node *, vcount_t, List<TR::Node> *, List<TR_NodeParentSymRef> *, List<TR_NodeParentSymRefWeightTuple> *, TR::Node *, bool, TR::Block *, int32_t);
    void findAndReplaceContigArrayLen(TR::Node *, TR::Node *, vcount_t);


### PR DESCRIPTION
Versioner currently treats loads of fields and statics as loop-invariant (when the loop doesn't explicitly write them) and generates versioning tests containing such loads. If another thread writes to a field or static, it's possible for the value observed by the loop body to differ from the value observed in a versioning test. For a load that has been copied into multiple versioning tests, it is even possible to see values that are inconsistent between versioning tests. In particular, after running a versioning test, the property it tests for may no longer hold of the value obtained by repeating the load, so it is incorrect to skip checks.

In the absence of synchronization and calls it is possible to version based on expressions containing such loads by privatizing their values, guaranteeing that the values remain stable throughout the series of versioning tests and the hot loop body. However, doing so is a very large change.

For now, treat any node that would need to be privatized as non-invariant to prevent incorrect versioning.

The upstream OMR PR eclipse/omr#4138 has been merged. The parent of that commit was too new, so here the change has been rebased onto v0.15.0-release.