### PR TITLE
Remove redundant parm to avoid incorrect usage

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1028,12 +1028,12 @@ int32_t OMR::Compilation::compile()
 
    if (_ilGenSuccess)
       {
-      _methodSymbol->detectInternalCycles(_methodSymbol->getFlowGraph(), self());
+      _methodSymbol->detectInternalCycles();
 
       //detect catch blocks that could have normal predecessors
       //if so, fail the compile
       //
-      if (_methodSymbol->catchBlocksHaveRealPredecessors(_methodSymbol->getFlowGraph(), self()))
+      if (_methodSymbol->catchBlocksHaveRealPredecessors())
          {
          self()->failCompilation<TR::CompilationException>("Catch blocks have real predecessors");
          }

--- a/compiler/il/OMRResolvedMethodSymbol.cpp
+++ b/compiler/il/OMRResolvedMethodSymbol.cpp
@@ -1214,7 +1214,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
             {
             if (!comp->isPeekingMethod())
                {
-               if (self()->catchBlocksHaveRealPredecessors(comp->getFlowGraph(), comp))
+               if (self()->catchBlocksHaveRealPredecessors())
                   {
                   comp->failCompilation<TR::CompilationException>("Catch blocks have real predecessors");
                   }
@@ -1235,7 +1235,7 @@ OMR::ResolvedMethodSymbol::genIL(TR_FrontEnd * fe, TR::Compilation * comp, TR::S
             previousOptimizer = comp->getOptimizer();
             comp->setOptimizer(optimizer);
 
-            self()->detectInternalCycles(comp->getFlowGraph(), comp);
+            self()->detectInternalCycles();
 
             if (doOSR)
                {
@@ -2081,8 +2081,10 @@ OMR::ResolvedMethodSymbol::setFirstTreeTop(TR::TreeTop * tt)
    }
 
 bool
-OMR::ResolvedMethodSymbol::detectInternalCycles(TR::CFG *cfg, TR::Compilation *comp)
+OMR::ResolvedMethodSymbol::detectInternalCycles()
    {
+   TR::CFG *cfg = self()->getFlowGraph();
+   TR::Compilation *comp = self()->comp();
    if (cfg)
       {
       int32_t numNodesInCFG = 0;
@@ -2196,16 +2198,16 @@ OMR::ResolvedMethodSymbol::detectInternalCycles(TR::CFG *cfg, TR::Compilation *c
    }
 
 bool
-OMR::ResolvedMethodSymbol::catchBlocksHaveRealPredecessors(TR::CFG *cfg, TR::Compilation *comp)
+OMR::ResolvedMethodSymbol::catchBlocksHaveRealPredecessors()
    {
-   for (TR::CFGNode *node = cfg->getFirstNode(); node; node = node->getNext())
+   for (TR::CFGNode *node = self()->getFlowGraph()->getFirstNode(); node; node = node->getNext())
       {
       if (!node->getExceptionPredecessors().empty())
          {
          //catch block
          if (!node->getPredecessors().empty())
             {
-            dumpOptDetails(comp, "detected catch block_%d with real predecessors\n", node->getNumber());
+            dumpOptDetails(self()->comp(), "detected catch block_%d with real predecessors\n", node->getNumber());
             return true;
             }
          }

--- a/compiler/il/OMRResolvedMethodSymbol.hpp
+++ b/compiler/il/OMRResolvedMethodSymbol.hpp
@@ -271,8 +271,8 @@ public:
    bool hasSnapshots()                       { return _properties.testAny(HasSnapshots); }
    void setHasSnapshots(bool v=true)         { _properties.set(HasSnapshots,v); }
 
-   bool detectInternalCycles(TR::CFG *cfg, TR::Compilation *comp);
-   bool catchBlocksHaveRealPredecessors(TR::CFG *cfg, TR::Compilation *comp);
+   bool detectInternalCycles();
+   bool catchBlocksHaveRealPredecessors();
 
    void setCannotAttemptOSR(int32_t n);
    bool cannotAttemptOSRAt(TR_ByteCodeInfo &bci, TR::Block *blockToOSRAt, TR::Compilation *comp);


### PR DESCRIPTION
Both `detectInternalCycles` and `catchBlocksHaveRealPredecessors` are
intended to detect patterns in the CFG of the receiver method symbol.
When calling from `OMR::ResolvedMethodSymbol::genIL` the CFG of the
compiling method is passed in rather than the method whose IL is
generated which is incorrect.
Remove the CFG parm which can be obtained from self()->getFlowGraph() to
avoid incorrect use of the API.

Cherry pick of https://github.com/eclipse/omr/pull/4691

Signed-off-by: Yi Zhang <yizhang@ca.ibm.com>