### PR TITLE
Create and use CodeGenerator flag for recompilation support (0.20.0)

### DIFF
--- a/compiler/arm/codegen/OMRCodeGenerator.cpp
+++ b/compiler/arm/codegen/OMRCodeGenerator.cpp
@@ -133,6 +133,8 @@ OMR::ARM::CodeGenerator::CodeGenerator()
    // TODO: Disable FP-GRA since current GRA does not work well with ARM linkage (where Float register usage is limited).
    self()->setDisableFpGRA();
 
+   self()->setSupportsRecompilation();
+
    self()->setSupportsGlRegDeps();
    self()->setSupportsGlRegDepOnFirstBlock();
    self()->setPerformsChecksExplicitly();

--- a/compiler/codegen/OMRCodeGenerator.hpp
+++ b/compiler/codegen/OMRCodeGenerator.hpp
@@ -1453,6 +1453,17 @@ class OMR_EXTENSIBLE CodeGenerator
    bool getSupportsGlRegDeps() {return _flags1.testAny(SupportsGlRegDeps);}
    void setSupportsGlRegDeps() {_flags1.set(SupportsGlRegDeps);}
 
+   /**
+    * @brief Query whether this code generator supports recompilation
+    * @return true if recompilation supported; false otherwise
+    */
+   bool getSupportsRecompilation() {return _flags1.testAny(SupportsRecompilation);}
+
+   /**
+    * @brief Indicate code generator support for recompilation
+    */
+   void setSupportsRecompilation() {_flags1.set(SupportsRecompilation);}
+
    bool getSupportsVectorRegisters() {return _flags1.testAny(SupportsVectorRegisters);}
    void setSupportsVectorRegisters() {_flags1.set(SupportsVectorRegisters);}
 
@@ -1714,7 +1725,7 @@ class OMR_EXTENSIBLE CodeGenerator
       SupportsReferenceArrayCopy                         = 0x00000200,
       SupportsJavaFloatSemantics                         = 0x00000400,
       SupportsInliningOfTypeCoersionMethods              = 0x00000800,
-      // AVAILABLE                                       = 0x00001000,
+      SupportsRecompilation                              = 0x00001000,
       SupportsVectorRegisters                            = 0x00002000,
       SupportsGlRegDepOnFirstBlock                       = 0x00004000,
       SupportsRemAsThirdChildOfDiv                       = 0x00008000,

--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -401,7 +401,9 @@ OMR::Compilation::Compilation(
 
    //codegen also needs _methodSymbol
    _codeGenerator = allocateCodeGenerator(self());
-   _recompilationInfo = _codeGenerator->allocateRecompilationInfo();
+
+   _recompilationInfo = _codeGenerator->getSupportsRecompilation() ? _codeGenerator->allocateRecompilationInfo() : NULL;
+
    _globalRegisterCandidates = new (self()->trHeapMemory()) TR_RegisterCandidates(self());
 
 #ifdef J9_PROJECT_SPECIFIC

--- a/compiler/p/codegen/OMRCodeGenerator.cpp
+++ b/compiler/p/codegen/OMRCodeGenerator.cpp
@@ -170,6 +170,8 @@ OMR::Power::CodeGenerator::CodeGenerator() :
    self()->setSupportsGlRegDeps();
    self()->setSupportsGlRegDepOnFirstBlock();
 
+   self()->setSupportsRecompilation();
+
    if (self()->comp()->target().is32Bit())
       self()->setUsesRegisterPairsForLongs();
 

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -401,6 +401,7 @@ OMR::X86::CodeGenerator::initialize(TR::Compilation *comp)
          }
       }
 
+   self()->setSupportsRecompilation();
    self()->setSupportsScaledIndexAddressing();
    self()->setSupportsConstantOffsetInAddressing();
    self()->setSupportsCompactedLocals();

--- a/compiler/z/codegen/OMRCodeGenerator.cpp
+++ b/compiler/z/codegen/OMRCodeGenerator.cpp
@@ -563,6 +563,8 @@ OMR::Z::CodeGenerator::CodeGenerator()
       comp->setOption(TR_DisableVectorRegGRA);
       }
 
+   self()->setSupportsRecompilation();
+
    // This enables the tactical GRA
    self()->setSupportsGlRegDeps();
 


### PR DESCRIPTION
* Add CodeGenerator flag indicating support for recompilation
* Do not allocate recompilation info if recompilation not supported 

Port of https://github.com/eclipse/omr/pull/4917