### PR TITLE
(0.20.0) AArch64: Correct the binary encoding of 64-bit "extr" instruction

### DIFF
--- a/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstOpCodeEnum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corp. and others
+ * Copyright (c) 2018, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -314,7 +314,7 @@
 		ubfmx,                                                  	/* 0xD3400000	UBFM      	 */
 	/* Extract */
 		extrw,                                                  	/* 0x13800000	EXTR      	 */
-		extrx,                                                  	/* 0x93C08000	EXTR      	 */
+		extrx,                                                  	/* 0x93C00000	EXTR      	 */
 /* Data Processing - register */
 	/* Logical (shifted register) */
 		andw,                                                   	/* 0x0A000000	AND       	 */


### PR DESCRIPTION
This is a followup of #4932, correcting the binary encoding of
64-bit "extr" instruction of AArch64.

PR in master: eclipse/omr#4937

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>