### PR TITLE
(0.20.0) Fix VP constraint merging for multi-dimensional arrays

### DIFF
--- a/compiler/optimizer/VPConstraint.cpp
+++ b/compiler/optimizer/VPConstraint.cpp
@@ -3495,7 +3495,10 @@ TR::VPConstraint *TR::VPFixedClass::intersect1(TR::VPConstraint *other, OMR::Val
             }
 
          if ((*thisSig != 'L') && ((*otherSig == 'L') || (*otherSig == '[')))
-            return NULL;
+            {
+            if (! ((*thisSig == '[') && (otherLen == 18 && !strncmp(otherSig, "Ljava/lang/Object;", 18))) )
+               return NULL;
+            }
 
          // retain the fact that its a fixed type
          return this;


### PR DESCRIPTION
When intersecting VP constraints involving an unresolved class, permit
the intersection of a multi-dimensional array and an array of
java/lang/Objects.  For example, the following constraints should be
mergeable:

   Fixed class:     [[I
   Unresolved class [Ljava/lang/Object;

Closes: eclipse/openj9#8869

Master PR: eclipse/omr#4944

Signed-off-by: Daryl Maier <maier@ca.ibm.com>