### PR TITLE
(0.20.0) Fix reference to global align

### DIFF
--- a/compiler/runtime/OMRCodeCache.hpp
+++ b/compiler/runtime/OMRCodeCache.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -82,8 +82,8 @@ public:
    uint8_t *getWarmCodeAlloc()   { return _warmCodeAlloc; }
    uint8_t *getColdCodeAlloc()   { return _coldCodeAlloc; }
 
-   void alignWarmCodeAlloc(uint32_t round)  { _warmCodeAlloc = align(_warmCodeAlloc, round); }
-   void alignColdCodeAlloc(uint32_t round)  { _coldCodeAlloc = align(_coldCodeAlloc, round); }
+   void alignWarmCodeAlloc(uint32_t round)  { _warmCodeAlloc = ::align(_warmCodeAlloc, round); }
+   void alignColdCodeAlloc(uint32_t round)  { _coldCodeAlloc = ::align(_coldCodeAlloc, round); }
 
    TR::CodeCache * getNextCodeCache()  { return _next; }
 


### PR DESCRIPTION
This code is intending to refer to ::align() (i.e. a function in the global
namespace, defined in compiler/runtime/Alignment.cpp).

However since the code is itself in the OMR namespace and the align()
is unqalified the compiler will choose OMR::align() in compilation units
that include that definition, and that definition is incompatible both
lexically and functionally.

Unfortunately ::align() and Alignment.cpp are referenced in downstream
projects and so we can't just fix it in the most sensible way without
breaking things first, so instead just make sure this use of align is
properly qualified.

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>
(cherry picked from commit 41ea62b3734a2892ee8aadf600a2b626dc93261c)

Port of https://github.com/eclipse/omr/pull/4943.