### PR TITLE
(0.20.0) AArch64: Set the enforceStoreOrder flag

### DIFF
--- a/compiler/aarch64/codegen/OMRCodeGenerator.cpp
+++ b/compiler/aarch64/codegen/OMRCodeGenerator.cpp
@@ -127,6 +127,8 @@ OMR::ARM64::CodeGenerator::CodeGenerator() :
 
    self()->getLinkage()->setParameterLinkageRegisterIndex(self()->comp()->getJittedMethodSymbol());
 
+   if (self()->comp()->target().isSMP())
+      self()->setEnforceStoreOrder();
    }
 
 void


### PR DESCRIPTION
This commit sets the enforceStoreOrder flag on AArch64 SMP.

Original PR for master: eclipse/omr#4972

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>