### PR TITLE
(0.20.0) Fix memory barrier functions in VM_AtomicSupport

### DIFF
--- a/include_core/AtomicSupport.hpp
+++ b/include_core/AtomicSupport.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -205,9 +205,9 @@ public:
 		asm volatile("lock orl $0x0,(%%rsp)" ::: "memory");
 #elif defined(ARM) /* defined(J9HAMMER) */
 		__sync_synchronize();
-#elif defined(AARCH64) /* defined(ARM) */
+#elif defined(OMR_ARCH_AARCH64) /* defined(ARM) */
 		__asm __volatile ("dmb ish":::"memory");
-#elif defined(S390) /* defined(AARCH64) */
+#elif defined(S390) /* defined(OMR_ARCH_AARCH64) */
 		asm volatile("bcr 15,0":::"memory");
 #else /* defined(S390) */
 		asm volatile("":::"memory");
@@ -240,9 +240,9 @@ public:
 #elif defined(__GNUC__)
 #if defined(ARM)
 		__sync_synchronize();
-#elif defined(AARCH64) /* defined(ARM) */
+#elif defined(OMR_ARCH_AARCH64) /* defined(ARM) */
 		__asm __volatile ("dmb ishst":::"memory");
-#else /* defined(AARCH64) */
+#else /* defined(OMR_ARCH_AARCH64) */
 		asm volatile("":::"memory");
 #endif /* defined(ARM) */
 #elif defined(J9ZOS390)
@@ -270,9 +270,9 @@ public:
 #elif defined(__GNUC__)
 #if defined(ARM)
 		__sync_synchronize();
-#elif defined(AARCH64) /* defined(ARM) */
+#elif defined(OMR_ARCH_AARCH64) /* defined(ARM) */
 		__asm __volatile ("dmb ishld":::"memory");
-#else /* defined(AARCH64) */
+#else /* defined(OMR_ARCH_AARCH64) */
 		asm volatile("":::"memory");
 #endif /* defined(ARM) */
 #elif defined(J9ZOS390)

--- a/include_core/omrcfg.cmake.h.in
+++ b/include_core/omrcfg.cmake.h.in
@@ -126,6 +126,11 @@
 #cmakedefine OMR_ARCH_ARM
 
 /**
+ * This spec targets AARCH64 processors.
+ */
+#cmakedefine OMR_ARCH_AARCH64
+
+/**
  * This spec targets x86 processors.
  */
 #cmakedefine OMR_ARCH_X86

--- a/include_core/omrcfg.h.in
+++ b/include_core/omrcfg.h.in
@@ -124,6 +124,11 @@
 #undef OMR_ARCH_ARM
 
 /**
+ * This spec targets AARCH64 processors.
+ */
+#undef OMR_ARCH_AARCH64
+
+/**
  * This spec targets x86 processors.
  */
 #undef OMR_ARCH_X86


### PR DESCRIPTION
The memory barrier functions in `VM_AtomicSupport` uses `#ifdef` to support multiple platforms, but `AARCH64` is not defined for OpenJ9 builds. Thus, memory barrier functions were empty for aarch64 OpenJ9 builds.
With these commits, `OMR_ARCH_AARCH64` is defined for both CMake and autotools builds, and used in `VM_AtomicSupport` instead of `AARCH64`.

Master PRs: 
- https://github.com/eclipse/omr/pull/4982
- https://github.com/eclipse/omr/pull/4983
- https://github.com/eclipse/omr/pull/4984