### PR TITLE
(0.20.0) AArch64: Call redoTrampolineReservationIfNecessary()

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -95,6 +95,12 @@ uint8_t *TR::ARM64ImmSymInstruction::generateBinaryEncoding()
       else
          {
          TR::MethodSymbol *method = symRef->getSymbol()->getMethodSymbol();
+
+         if (cg()->hasCodeCacheSwitched())
+            {
+            cg()->redoTrampolineReservationIfNecessary(this, symRef);
+            }
+
          if (method && method->isHelper())
             {
             intptrj_t destination = (intptrj_t)symRef->getMethodAddress();


### PR DESCRIPTION
This commit adds a call to redoTrampolineReservationIfNecessary()
upon hasCodeCacheSwitched() in generateBinaryEncoding() for
ARM64ImmSymInstruction.

Original PR for master: eclipse/omr#5052

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>