### PR TITLE
(0.21.0) Implement ARM64Trg1Src2ZeroInstruction

### DIFF
--- a/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
+++ b/compiler/aarch64/codegen/ARM64BinaryEncoding.cpp
@@ -460,11 +460,10 @@ uint8_t *TR::ARM64Trg1ZeroSrc1Instruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
-   TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
    insertTargetRegister(toARM64Cursor(cursor));
    insertSource1Register(toARM64Cursor(cursor));
-   zeroReg->setRegisterFieldRN(toARM64Cursor(cursor));
+   insertZeroRegister(toARM64Cursor(cursor));
    cursor += ARM64_INSTRUCTION_LENGTH;
    setBinaryLength(ARM64_INSTRUCTION_LENGTH);
    setBinaryEncoding(instructionStart);
@@ -490,10 +489,8 @@ uint8_t *TR::ARM64ZeroSrc1ImmInstruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
-   TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
-
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
-   zeroReg->setRegisterFieldRD(toARM64Cursor(cursor));
+   insertZeroRegister(toARM64Cursor(cursor));
    insertSource1Register(toARM64Cursor(cursor));
    insertImmediateField(toARM64Cursor(cursor));
    insertNbit(toARM64Cursor(cursor));
@@ -556,6 +553,21 @@ uint8_t *TR::ARM64Trg1Src2ExtendedInstruction::generateBinaryEncoding()
    insertSource1Register(toARM64Cursor(cursor));
    insertSource2Register(toARM64Cursor(cursor));
    insertExtend(toARM64Cursor(cursor));
+   cursor += ARM64_INSTRUCTION_LENGTH;
+   setBinaryLength(ARM64_INSTRUCTION_LENGTH);
+   setBinaryEncoding(instructionStart);
+   return cursor;
+   }
+
+uint8_t *TR::ARM64Trg1Src2ZeroInstruction::generateBinaryEncoding()
+   {
+   uint8_t *instructionStart = cg()->getBinaryBufferCursor();
+   uint8_t *cursor = instructionStart;
+   cursor = getOpCode().copyBinaryToBuffer(instructionStart);
+   insertTargetRegister(toARM64Cursor(cursor));
+   insertSource1Register(toARM64Cursor(cursor));
+   insertSource2Register(toARM64Cursor(cursor));
+   insertZeroRegister(toARM64Cursor(cursor));
    cursor += ARM64_INSTRUCTION_LENGTH;
    setBinaryLength(ARM64_INSTRUCTION_LENGTH);
    setBinaryEncoding(instructionStart);
@@ -702,10 +714,8 @@ uint8_t *TR::ARM64ZeroSrc2Instruction::generateBinaryEncoding()
    {
    uint8_t *instructionStart = cg()->getBinaryBufferCursor();
    uint8_t *cursor = instructionStart;
-   TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
-
    cursor = getOpCode().copyBinaryToBuffer(instructionStart);
-   zeroReg->setRegisterFieldRD(toARM64Cursor(cursor));
+   insertZeroRegister(toARM64Cursor(cursor));
    insertSource1Register(toARM64Cursor(cursor));
    insertSource2Register(toARM64Cursor(cursor));
    cursor += ARM64_INSTRUCTION_LENGTH;

--- a/compiler/aarch64/codegen/ARM64Debug.cpp
+++ b/compiler/aarch64/codegen/ARM64Debug.cpp
@@ -595,6 +595,9 @@ TR_Debug::print(TR::FILE *pOutFile, TR::Instruction *instr)
       case OMR::Instruction::IsTrg1Src2Extended:
          print(pOutFile, (TR::ARM64Trg1Src2ExtendedInstruction *)instr);
          break;
+      case OMR::Instruction::IsTrg1Src2Zero:
+         print(pOutFile, (TR::ARM64Trg1Src2ZeroInstruction *)instr);
+         break;
       case OMR::Instruction::IsTrg1Src3:
          print(pOutFile, (TR::ARM64Trg1Src3Instruction *)instr);
          break;
@@ -1200,23 +1203,8 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2Instruction *instr)
    {
    printPrefix(pOutFile, instr);
    TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
-   bool isCmp = false;
-   if (op == TR::InstOpCode::subsx || op == TR::InstOpCode::subsw)
-      {
-      TR::Register *r = instr->getTargetRegister();
-      if (r && r->getRealRegister()
-          && toRealRegister(r)->getRegisterNumber() == TR::RealRegister::xzr)
-         {
-         // cmp alias
-         isCmp = true;
-         trfprintf(pOutFile, "cmp%c \t", (op == TR::InstOpCode::subsx) ? 'x' : 'w');
-         }
-      }
-   if (!isCmp)
-      {
-      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
-      print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
-      }
+   trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource2Register(), TR_WordReg);
 
@@ -1296,6 +1284,26 @@ TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2ExtendedInstruction *instr)
    print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
    print(pOutFile, instr->getSource2Register(), TR_WordReg);
    trfprintf(pOutFile, " %s %d", ARM64ExtendCodeNames[instr->getExtendType()], instr->getShiftAmount());
+   trfflush(_comp->getOutFile());
+   }
+
+void
+TR_Debug::print(TR::FILE *pOutFile, TR::ARM64Trg1Src2ZeroInstruction *instr)
+   {
+   printPrefix(pOutFile, instr);
+   TR::InstOpCode::Mnemonic op = instr->getOpCodeValue();
+   if (op == TR::InstOpCode::maddx || op == TR::InstOpCode::maddw)
+      {
+      // mul alias
+      trfprintf(pOutFile, "mul%c \t", (op == TR::InstOpCode::maddx) ? 'x' : 'w');
+      }
+   else
+      {
+      trfprintf(pOutFile, "%s \t", getOpCodeName(&instr->getOpCode()));
+      }
+   print(pOutFile, instr->getTargetRegister(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource1Register(), TR_WordReg); trfprintf(pOutFile, ", ");
+   print(pOutFile, instr->getSource2Register(), TR_WordReg);
    trfflush(_comp->getOutFile());
    }
 

--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -1578,7 +1578,7 @@ class ARM64Trg1Src1Instruction : public ARM64Trg1Instruction
 
 /*
  * This class is designated to be used for alias instruction such as movw, movx, negw, negx
- */ 
+ */
 class ARM64Trg1ZeroSrc1Instruction : public ARM64Trg1Src1Instruction
    {
    public:
@@ -1627,6 +1627,16 @@ class ARM64Trg1ZeroSrc1Instruction : public ARM64Trg1Src1Instruction
       {
       TR::RealRegister *source1 = toRealRegister(getSource1Register());
       source1->setRegisterFieldRM(instruction);
+      }
+
+   /**
+    * @brief Sets zero register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertZeroRegister(uint32_t *instruction)
+      {
+      TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+      zeroReg->setRegisterFieldRN(instruction);
       }
 
    /**
@@ -2296,6 +2306,75 @@ class ARM64Trg1Src2ExtendedInstruction : public ARM64Trg1Src2Instruction
    void insertExtend(uint32_t *instruction)
       {
       *instruction |= ((_extendType & 0x7) << 13) | ((_shiftAmount & 0x7) << 10);
+      }
+
+   /**
+    * @brief Generates binary encoding of the instruction
+    * @return instruction cursor
+    */
+   virtual uint8_t *generateBinaryEncoding();
+   };
+
+/*
+ * This class is designated to be used for alias instruction such as mulw, mulx
+ */
+class ARM64Trg1Src2ZeroInstruction : public ARM64Trg1Src2Instruction
+   {
+   public:
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src2ZeroInstruction( TR::InstOpCode::Mnemonic op,
+                                 TR::Node *node,
+                                 TR::Register *treg,
+                                 TR::Register *s1reg,
+                                 TR::Register *s2reg,
+                                 TR::CodeGenerator *cg)
+      : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, cg)
+      {
+      }
+
+   /*
+    * @brief Constructor
+    * @param[in] op : instruction opcode
+    * @param[in] node : node
+    * @param[in] treg : target register
+    * @param[in] s1reg : source register 1
+    * @param[in] s2reg : source register 2
+    * @param[in] precedingInstruction : preceding instruction
+    * @param[in] cg : CodeGenerator
+    */
+   ARM64Trg1Src2ZeroInstruction( TR::InstOpCode::Mnemonic op,
+                                 TR::Node *node,
+                                 TR::Register *treg,
+                                 TR::Register *s1reg,
+                                 TR::Register *s2reg,
+                                 TR::Instruction *precedingInstruction, TR::CodeGenerator *cg)
+      : ARM64Trg1Src2Instruction(op, node, treg, s1reg, s2reg, precedingInstruction, cg)
+      {
+      }
+
+   /**
+    * @brief Gets instruction kind
+    * @return instruction kind
+    */
+   virtual Kind getKind() { return IsTrg1Src2Zero; }
+
+   /**
+    * @brief Sets zero register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertZeroRegister(uint32_t *instruction)
+      {
+      TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+      zeroReg->setRegisterFieldRA(instruction);
       }
 
    /**
@@ -3171,7 +3250,7 @@ class ARM64Src1Instruction : public TR::Instruction
 
 /*
  * This class is designated to be used for alias instruction such as cmpimmw, cmpimmx, tstimmw, tstimmx
- */ 
+ */
 class ARM64ZeroSrc1ImmInstruction : public ARM64Src1Instruction
    {
    uint32_t _source1Immediate;
@@ -3268,8 +3347,18 @@ class ARM64ZeroSrc1ImmInstruction : public ARM64Src1Instruction
     * @brief Sets the N bit (bit 22)
     * @param[in] n : N bit value
     * @return N bit value
-    */ 
+    */
    bool setNbit(bool n) { return (_Nbit = n);}
+
+   /**
+    * @brief Sets zero register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertZeroRegister(uint32_t *instruction)
+      {
+      TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+      zeroReg->setRegisterFieldRD(instruction);
+      }
 
    /**
     * @brief Sets immediate field in binary encoding
@@ -3461,6 +3550,16 @@ class ARM64ZeroSrc2Instruction : public ARM64Src2Instruction
     * @return instruction kind
     */
    virtual Kind getKind() { return IsZeroSrc2; }
+
+   /**
+    * @brief Sets zero register in binary encoding
+    * @param[in] instruction : instruction cursor
+    */
+   void insertZeroRegister(uint32_t *instruction)
+      {
+      TR::RealRegister *zeroReg = cg()->machine()->getRealRegister(TR::RealRegister::xzr);
+      zeroReg->setRegisterFieldRD(instruction);
+      }
 
    /**
     * @brief Generates binary encoding of the instruction

--- a/compiler/aarch64/codegen/GenerateInstructions.cpp
+++ b/compiler/aarch64/codegen/GenerateInstructions.cpp
@@ -448,19 +448,9 @@ TR::Instruction *generateMulInstruction(TR::CodeGenerator *cg, TR::Node *node,
    bool is64bit = node->getDataType().isInt64();
    TR::InstOpCode::Mnemonic op = is64bit ? TR::InstOpCode::maddx : TR::InstOpCode::maddw;
 
-   /* Use xzr as the third source register */
-   TR::Register *zeroReg = cg->allocateRegister();
-   TR::RegisterDependencyConditions *cond = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(1, 1, cg->trMemory());
-   TR::addDependency(cond, zeroReg, TR::RealRegister::xzr, TR_GPR, cg);
-
-   TR::Instruction *instr =
-      (preced) ?
-      new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, preced, cg) :
-      new (cg->trHeapMemory()) TR::ARM64Trg1Src3Instruction(op, node, treg, s1reg, s2reg, zeroReg, cond, cg);
-
-   cg->stopUsingRegister(zeroReg);
-
-   return instr;
+   if (preced)
+      return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ZeroInstruction(op, node, treg, s1reg, s2reg, preced, cg);
+   return new (cg->trHeapMemory()) TR::ARM64Trg1Src2ZeroInstruction(op, node, treg, s1reg, s2reg, cg);
    }
 
 TR::Instruction *generateCSetInstruction(TR::CodeGenerator *cg, TR::Node *node,

--- a/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
+++ b/compiler/aarch64/codegen/OMRInstructionKindEnum.hpp
@@ -47,6 +47,7 @@
             IsCondTrg1Src2,
             IsTrg1Src2Shifted,
             IsTrg1Src2Extended,
+            IsTrg1Src2Zero,
             IsTrg1Src3,
       IsTrg1Mem,
          IsTrg1MemSrc1,

--- a/compiler/ras/Debug.hpp
+++ b/compiler/ras/Debug.hpp
@@ -351,6 +351,7 @@ namespace TR { class ARM64Trg1Src2Instruction; }
 namespace TR { class ARM64CondTrg1Src2Instruction; }
 namespace TR { class ARM64Trg1Src2ShiftedInstruction; }
 namespace TR { class ARM64Trg1Src2ExtendedInstruction; }
+namespace TR { class ARM64Trg1Src2ZeroInstruction; }
 namespace TR { class ARM64Trg1Src3Instruction; }
 namespace TR { class ARM64Trg1MemInstruction; }
 namespace TR { class ARM64MemInstruction; }
@@ -1125,6 +1126,7 @@ public:
    void print(TR::FILE *, TR::ARM64CondTrg1Src2Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2ShiftedInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src2ExtendedInstruction *);
+   void print(TR::FILE *, TR::ARM64Trg1Src2ZeroInstruction *);
    void print(TR::FILE *, TR::ARM64Trg1Src3Instruction *);
    void print(TR::FILE *, TR::ARM64Trg1MemInstruction *);
    void print(TR::FILE *, TR::ARM64MemInstruction *);


### PR DESCRIPTION
This commit implements ARM64Trg1Src2ZeroInstruction class so that we can
stop setting register dependencies on the zero register in generating
instructions for integer multiply.

This commit also contains the following changes:

- Implement and use insertZeroRegister() functions in classes introduced by #61
- Remove the code for printing "cmp" from ARM64Trg1Src2Instruction
(It was moved to ARM64ZeroSrc2Instruction)

Original PRs for master: eclipse/omr#5289, eclipse/omr#5290

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>