### PR TITLE
(0.21.0) get_processor_info OSX procInfoArray[0].online should be ONLINE

### DIFF
--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -4342,6 +4342,7 @@ retrieveOSXProcessorStats(struct OMRPortLibrary *portLibrary, struct J9Processor
 			procInfo->procInfoArray[0].idleTime += procInfo->procInfoArray[i + 1].idleTime;
 			procInfo->procInfoArray[0].busyTime += procInfo->procInfoArray[i + 1].busyTime;
 		}
+		procInfo->procInfoArray[0].online = OMRPORT_PROCINFO_PROC_ONLINE;
 		ret = 0;
 	}
 	return ret;


### PR DESCRIPTION
Every other platform sets procInfoArray[0].online to
OMRPORT_PROCINFO_PROC_ONLINE. Index 0 is used for the total processor
information.

Cherry pick of https://github.com/eclipse/omr/pull/5299 for the 0.21.0 release.
Fixes https://github.com/eclipse/openj9/issues/8709