### PR TITLE
(0.21.0) AArch64: Enable Recompilation

### DIFF
--- a/compiler/aarch64/codegen/ARM64Instruction.hpp
+++ b/compiler/aarch64/codegen/ARM64Instruction.hpp
@@ -203,6 +203,7 @@ public:
       : TR::Instruction(op, node, cg),
         _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
       {
+      setNeedsAOTRelocation();
       }
    /*
     * @brief Constructor
@@ -219,6 +220,7 @@ public:
       : TR::Instruction(op, node, precedingInstruction, cg),
         _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(NULL)
       {
+      setNeedsAOTRelocation();
       }
    /*
     * @brief Constructor
@@ -235,6 +237,7 @@ public:
       : TR::Instruction(op, node, cg),
         _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
       {
+      setNeedsAOTRelocation();
       }
    /*
     * @brief Constructor
@@ -252,6 +255,7 @@ public:
       : TR::Instruction(op, node, precedingInstruction, cg),
         _sourceImmediate(imm), _reloKind(relocationKind), _symbolReference(sr)
       {
+      setNeedsAOTRelocation();
       }
 
    /**

--- a/compiler/control/OMROptions.cpp
+++ b/compiler/control/OMROptions.cpp
@@ -2629,6 +2629,10 @@ OMR::Options::jitPreProcess()
 #if defined(TR_HOST_ARM64)
       // Prefetch is not supported on ARM64 yet
       _disabledOptimizations[prefetchInsertion] = true;
+
+      // Profiling is not supported on ARM64 yet
+      // Eclipse OpenJ9 Issue #9881
+      self()->setOption(TR_DisableProfiling);
 #endif
 
       self()->setOption(TR_DisableThunkTupleJ2I); // JSR292:TODO: Figure out how to do this without confusing startPCIfAlreadyCompiled


### PR DESCRIPTION
This commit enables recompilation for AArch64.

Original PRs for master: eclipse/omr#5281, eclipse/omr#5319

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>