### PR TITLE
Fix bugs in building DefiningMaps

### DIFF
--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -870,7 +870,8 @@ TR_OSRMethodData::buildDefiningMap(TR::Block *block, DefiningMap *blockMap, Defi
                }
             }
          }
-      else if (node->getFirstChild() &&
+      else if (node->getNumChildren() > 0 &&
+               node->getFirstChild() &&
                node->getFirstChild()->getOpCode().isCall() &&
                node->getFirstChild()->getSymbolReference()->getReferenceNumber() == TR_prepareForOSR)
          {

--- a/compiler/compile/OSRData.cpp
+++ b/compiler/compile/OSRData.cpp
@@ -581,7 +581,7 @@ void TR_OSRCompilationData::buildDefiningMap(TR::Region &region)
       TR::Block *osrCatchBlock = osrMethodData->getOSRCatchBlock();
       if (osrCatchBlock && osrCatchBlock->getExceptionPredecessors().size() > 0)
          {
-         definingMapAtOSRCatchBlocks[i] = new DefiningMap(DefiningMapComparator(), DefiningMapAllocator(comp->trMemory()->currentStackRegion()));
+         definingMapAtOSRCatchBlocks[i] = new (comp->trMemory()->currentStackRegion()) DefiningMap(DefiningMapComparator(), DefiningMapAllocator(comp->trMemory()->currentStackRegion()));
          osrMethodData->buildDefiningMapForBlock(osrCatchBlock, definingMapAtOSRCatchBlocks[i]);
          }
       else osrCatchBlockRemoved = true;
@@ -589,8 +589,8 @@ void TR_OSRCompilationData::buildDefiningMap(TR::Region &region)
       TR::Block *osrCodeBlock = osrMethodData->getOSRCodeBlock();
       if (osrCodeBlock && osrCodeBlock->getPredecessors().size() > 0)
          {
-         definingMapAtOSRCodeBlocks[i] = new DefiningMap(DefiningMapComparator(), DefiningMapAllocator(comp->trMemory()->currentStackRegion()));
-         definingMapAtPrepareForOSRCalls[i] = new DefiningMap(DefiningMapComparator(), DefiningMapAllocator(comp->trMemory()->currentStackRegion()));
+         definingMapAtOSRCodeBlocks[i] = new (comp->trMemory()->currentStackRegion()) DefiningMap(DefiningMapComparator(), DefiningMapAllocator(comp->trMemory()->currentStackRegion()));
+         definingMapAtPrepareForOSRCalls[i] = new (comp->trMemory()->currentStackRegion()) DefiningMap(DefiningMapComparator(), DefiningMapAllocator(comp->trMemory()->currentStackRegion()));
          osrMethodData->buildDefiningMapForOSRCodeBlockAndPrepareForOSRCall(osrCodeBlock, definingMapAtOSRCodeBlocks[i], definingMapAtPrepareForOSRCalls[i]);
          }
       else osrCodeBlockRemoved = true;
@@ -920,7 +920,7 @@ TR_OSRMethodData::collectSubTreeSymRefs(TR::Node *node, TR_BitVector *subTreeSym
       {
       subTreeSymRefs->set(node->getSymbolReference()->getReferenceNumber());
       }
-   else if (node->getRegLoadStoreSymbolReference())
+   else if (node->getOpCode().isStoreReg() || node->getOpCode().isLoadReg())
       {
       subTreeSymRefs->set(node->getRegLoadStoreSymbolReference()->getReferenceNumber());
       }


### PR DESCRIPTION
The `buildDefiningMap` code was dormant until recently.  Three issues have been found with the implementation:

- `buildDefiningMap` uses global new
- `collectRegLoadStoreSymbolReferences` calls `getRegLoadStoreSymbolReference` without first checking the opcode of the node.
- `buildDefiningMap` calls to read the first child of a node without checking if the node has a first child

These changes were originally authored by Andrew Craik and merged on the OMR master branch under [OMR pull request #5314](https://github.com/eclipse/omr/pull/5314) and [OMR pull request #5321](https://github.com/eclipse/omr/pull/5321)
