### PR TITLE
(0.21.0)Update traceAllocationBytes with the size inside TLH in flushing TLH

### DIFF
--- a/gc/base/TLHAllocationInterface.cpp
+++ b/gc/base/TLHAllocationInterface.cpp
@@ -282,6 +282,11 @@ MM_TLHAllocationInterface::flushCache(MM_EnvironmentBase *env)
 	MM_GCExtensionsBase *extensions = env->getExtensions();
 	
 #if defined(OMR_GC_THREAD_LOCAL_HEAP)	
+	/* update traceAllocationBytes with allocatedSizeInsideTLH during flushing TLH Cache */
+	uintptr_t allocatedSizeInsideTLH = _owningEnv->getAllocatedSizeInsideTLH();
+	_owningEnv->_oolTraceAllocationBytes += allocatedSizeInsideTLH;
+	_owningEnv->_traceAllocationBytes += allocatedSizeInsideTLH;
+
 	if (!_owningEnv->isInlineTLHAllocateEnabled()) {
 		/* Clear out realHeapTop field; tlh code below will take care of rest */
 		_owningEnv->enableInlineTLHAllocate();


### PR DESCRIPTION
Add current allocated size inside TLH to traceAllocationBytes
during flushing TLH(the size inside TLH will be cleared after
flushing).

fix: https://github.com/eclipse/openj9/issues/9808

Port of https://github.com/eclipse/omr/pull/5339 for the 0.21.0 release.

Signed-off-by: Lin Hu linhu@ca.ibm.com