### PR TITLE
Check whether TLS storage for comp object was created before freeing it (0.22.0)

### DIFF
--- a/compiler/control/CompilationController.cpp
+++ b/compiler/control/CompilationController.cpp
@@ -37,10 +37,11 @@
 
 namespace TR { class CompilationInfo; }
 
-int32_t                 TR::CompilationController::_verbose = 0;
+int32_t                  TR::CompilationController::_verbose = 0;
 TR::CompilationStrategy *TR::CompilationController::_compilationStrategy = NULL;
 TR::CompilationInfo *    TR::CompilationController::_compInfo = 0;
-bool                    TR::CompilationController::_useController = false;
+bool                     TR::CompilationController::_useController = false;
+bool                     TR::CompilationController::_tlsCompObjCreated = false;
 
 
 bool TR::CompilationController::init(TR::CompilationInfo *compInfo)
@@ -67,13 +68,14 @@ bool TR::CompilationController::init(TR::CompilationInfo *compInfo)
       }
 
    tlsAlloc(OMR::compilation);
-
+   _tlsCompObjCreated = true;
    return _useController;
    }
 
 void TR::CompilationController::shutdown()
    {
-   tlsFree(OMR::compilation);
+   if (_tlsCompObjCreated)
+      tlsFree(OMR::compilation);
    if (!_useController)
       return;
 

--- a/compiler/control/OptimizationPlan.hpp
+++ b/compiler/control/OptimizationPlan.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2020 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -291,6 +291,7 @@ class CompilationController
    static TR::CompilationInfo     *_compInfo;        // stored here for convenience
    static int32_t                 _verbose;
    static bool                    _useController;
+   static bool                    _tlsCompObjCreated;
    };
 
 } // namespace TR


### PR DESCRIPTION
When the JIT fails initialization it proceeds with the
shutdown routines. In here the JIT tries to deallocate
the TLS storage for the compilation object. However,
because the JIT failed so early, this storage might
not have been allocated in the first place.
This PR checks whether the TLS storage was allocated
before attempting to free it.

Port of https://github.com/eclipse/omr/pull/5549 for the 0.22 release.

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>