### PR TITLE
(0.23.0) Support Int64 Length Node within setmemoryEvaluator

### DIFF
--- a/compiler/p/codegen/OMRTreeEvaluator.cpp
+++ b/compiler/p/codegen/OMRTreeEvaluator.cpp
@@ -4211,10 +4211,10 @@ TR::Register *OMR::Power::TreeEvaluator::setmemoryEvaluator(TR::Node *node, TR::
    generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rlwimi, node, valueReg, valueReg,  16, 0xffff0000);
    generateTrg1Src1Imm2Instruction(cg, TR::InstOpCode::rldimi, node, valueReg, valueReg,  32, 0xffffffff00000000);
 
-   generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::Op_cmpli, node, cndReg, lengthReg, 32);
+   generateTrg1Src1ImmInstruction(cg, lengthNode->getType().isInt32() ? TR::InstOpCode::cmpli4 : TR::InstOpCode::cmpli8, node, cndReg, lengthReg, 32);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::blt, node, residualLabel, cndReg);
 
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::srawi, node, tempReg, lengthReg, 5);
+   generateTrg1Src1ImmInstruction(cg, lengthNode->getType().isInt32() ? TR::InstOpCode::srawi : TR::InstOpCode::sradi, node, tempReg, lengthReg, 5);
    generateSrc1Instruction(cg, TR::InstOpCode::mtctr, node, tempReg);
    generateLabelInstruction(cg, TR::InstOpCode::label, node, loopStartLabel);
    generateMemSrc1Instruction(cg, TR::InstOpCode::std, node, TR::MemoryReference::createWithDisplacement(cg, dstAddrReg, 0, 8), valueReg);


### PR DESCRIPTION
setMemoryEvaluator generates a sequence of instructions that initializes
a segment of memory of a specified length with a specified value. This
commit enables Int64 Length Node support while maintaining support for
Int32.

Signed-off-by: AlenBadel <Alen.Badel@ibm.com>