### PR TITLE
Backport CCData changes from OMR master

### DIFF
--- a/compiler/codegen/CCData.cpp
+++ b/compiler/codegen/CCData.cpp
@@ -20,7 +20,6 @@
  *******************************************************************************/
 
 #include "codegen/CCData.hpp"
-#include "infra/Assert.hpp"
 
 using OMR::CCData;
 

--- a/compiler/codegen/CCData.cpp
+++ b/compiler/codegen/CCData.cpp
@@ -72,7 +72,7 @@ CCData::~CCData()
 
 bool CCData::put(const uint8_t * const value, const size_t sizeBytes, const size_t alignmentBytes, const key_t * const key, index_t &index)
    {
-   const OMR::CriticalSection cs(_lock);
+   const OMR::CriticalSection critsec(_lock);
 
    /**
     * Multiple compilation threads may be attempting to update the same value with
@@ -126,7 +126,7 @@ bool CCData::get(const index_t index, uint8_t * const value, const size_t sizeBy
 
 bool CCData::find(const key_t key, index_t * const index) const
    {
-   const OMR::CriticalSection cs(_lock);
+   const OMR::CriticalSection critsec(_lock);
    return find_unsafe(key, index);
    }
 

--- a/compiler/codegen/CCData.cpp
+++ b/compiler/codegen/CCData.cpp
@@ -19,6 +19,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include "omrcomp.h"
+#include "OMR/Bytes.hpp"
+
 #include "codegen/CCData.hpp"
 
 #include "infra/Monitor.hpp"
@@ -40,21 +43,22 @@ CCData::key_t CCData::key(const char * const str)
 #define DATA_SIZE_FROM_BYTES_SIZE(x) (((x) + (sizeof(data_t)) - 1) / (sizeof(data_t)))
 
 // Converts an alignment in units of bytes to an alignment in units of alignof(data_t).
-#define DATA_ALIGNMENT_FROM_BYTES_ALIGNMENT(x) (((x) + (alignof(data_t)) - 1) / (alignof(data_t)))
+#define DATA_ALIGNMENT_FROM_BYTES_ALIGNMENT(x) (((x) + (OMR_ALIGNOF(data_t)) - 1) / (OMR_ALIGNOF(data_t)))
 
 CCData::CCData(const size_t sizeBytes)
-: _data(new data_t[DATA_SIZE_FROM_BYTES_SIZE(sizeBytes)]), _capacity(DATA_SIZE_FROM_BYTES_SIZE(sizeBytes)), _putIndex(0), _lock(TR::Monitor::create("CCDataMutex")), _releaseData(false)
+: _data(new data_t[DATA_SIZE_FROM_BYTES_SIZE(sizeBytes)]), _capacity(DATA_SIZE_FROM_BYTES_SIZE(sizeBytes)), _putIndex(0), _lock(TR::Monitor::create("CCDataMutex")), _releaseData(true)
    {
    }
 
 CCData::CCData(uint8_t * const storage, const size_t sizeBytes)
-: CCData(alignStorage(storage, sizeBytes))
+: _putIndex(0), _lock(TR::Monitor::create("CCDataMutex")), _releaseData(false)
    {
-   }
-
-CCData::CCData(const storage_and_size_pair_t storageAndSize)
-: _data(storageAndSize.first), _capacity(storageAndSize.second), _putIndex(0), _lock(TR::Monitor::create("CCDataMutex")), _releaseData(true)
-   {
+   void *alignedStorage = storage;
+   size_t sizeBytesAfterAlignment = sizeBytes;
+   bool success = OMR::align(OMR_ALIGNOF(data_t), sizeof(data_t), alignedStorage, sizeBytesAfterAlignment) != NULL;
+   TR_ASSERT_FATAL(success, "Can't align CCData storage to required boundary");
+   _data = reinterpret_cast<data_t *>(alignedStorage);
+   _capacity = DATA_SIZE_FROM_BYTES_SIZE(sizeBytesAfterAlignment);
    }
 
 CCData::~CCData()
@@ -62,21 +66,8 @@ CCData::~CCData()
    // Memory for data can either be allocated by this class or passed in via
    // the constructor. If allocated, it has to be freed now; if passed in we can't free
    // it.
-   // The _data member var is a smart pointer that will automatically
-   // free the underlying memory when it goes out of scope. If memory was passed in
-   // via the constructor we have to release it now to prevent the smart pointer from
-   // freeing it.
    if (_releaseData)
-      _data.release();
-   }
-
-const CCData::storage_and_size_pair_t CCData::alignStorage(uint8_t * const storage, size_t sizeBytes)
-   {
-   // This function takes buffer, aligns it for data_t, and converts the size in bytes to the size in units of data_t.
-   // It returns the aligned pointer and adjusted size in an std::pair so that we can use it when calling a constructor in an initializer list.
-   void *alignedStorage = storage;
-   std::align(alignof(data_t), sizeof(data_t), alignedStorage, sizeBytes);
-   return std::make_pair(reinterpret_cast<data_t *>(alignedStorage), DATA_SIZE_FROM_BYTES_SIZE(sizeBytes));
+      delete [] _data;
    }
 
 bool CCData::put(const uint8_t * const value, const size_t sizeBytes, const size_t alignmentBytes, const key_t * const key, index_t &index)
@@ -97,7 +88,7 @@ bool CCData::put(const uint8_t * const value, const size_t sizeBytes, const size
    const size_t sizeDataUnits = DATA_SIZE_FROM_BYTES_SIZE(sizeBytes);
    const size_t alignmentDataUnits = DATA_ALIGNMENT_FROM_BYTES_ALIGNMENT(alignmentBytes);
    const size_t alignmentMask = alignmentDataUnits - 1;
-   const size_t alignmentPadding = (alignmentDataUnits - ((reinterpret_cast<uintptr_t>(_data.get() + _putIndex) / alignof(data_t)) & alignmentMask)) & alignmentMask;
+   const size_t alignmentPadding = (alignmentDataUnits - ((reinterpret_cast<uintptr_t>(_data + _putIndex) / OMR_ALIGNOF(data_t)) & alignmentMask)) & alignmentMask;
    const size_t remainingCapacity = _capacity - _putIndex;
 
    if (sizeDataUnits + alignmentPadding > remainingCapacity)
@@ -106,14 +97,14 @@ bool CCData::put(const uint8_t * const value, const size_t sizeBytes, const size
    _putIndex += alignmentPadding;
    index = _putIndex;
 
-   if (key != nullptr)
+   if (key != NULL)
       _mappings[*key] = _putIndex;
 
-   if (value != nullptr)
+   if (value != NULL)
       {
       std::copy(value,
                 value + sizeBytes,
-                reinterpret_cast<uint8_t *>(_data.get() + _putIndex));
+                reinterpret_cast<uint8_t *>(_data + _putIndex));
       }
 
    _putIndex += sizeDataUnits;
@@ -126,8 +117,8 @@ bool CCData::get(const index_t index, uint8_t * const value, const size_t sizeBy
    if (index >= _capacity)
       return false;
 
-   std::copy(reinterpret_cast<const uint8_t *>(_data.get() + index),
-             reinterpret_cast<const uint8_t *>(_data.get() + index) + sizeBytes,
+   std::copy(reinterpret_cast<const uint8_t *>(_data + index),
+             reinterpret_cast<const uint8_t *>(_data + index) + sizeBytes,
              value);
 
    return true;
@@ -142,9 +133,9 @@ bool CCData::find(const key_t key, index_t * const index) const
 bool CCData::find_unsafe(const key_t key, index_t * const index) const
    {
    auto e = _mappings.find(key);
-   if (e != _mappings.cend())
+   if (e != _mappings.end())
       {
-      if (index != nullptr)
+      if (index != NULL)
          *index = e->second;
       return true;
       }

--- a/compiler/codegen/CCData.hpp
+++ b/compiler/codegen/CCData.hpp
@@ -141,8 +141,9 @@ class CCData
        * @param[In] value Optional. A pointer to the value to put. If null, no data will be copied but the space will be allocated none the less.
        * @param[In] sizeBytes The size of the value pointed to.
        * @param[In] alignmentBytes The alignment (in bytes) to align the value to.
-       * @param[In] key Optional. The key to map the resulting index to. Without a key the index is the only reference to the data. If the key is already mapped to an index a TR_ASSERT_FATAL will be triggered.
+       * @param[In] key Optional. The key to map the resulting index to. Without a key the index is the only reference to the data. If the key is already mapped to an index the operation will return the index and true, but no data will be written.
        * @param[Out] index The index that refers to the value.
+       * @return True if the value was placed in the table, or the key was already mapped to an index, false otherwise.
        */
       bool put(const uint8_t * const value, const size_t sizeBytes, const size_t alignmentBytes, const key_t * const key, index_t &index);
 

--- a/compiler/codegen/CCData.hpp
+++ b/compiler/codegen/CCData.hpp
@@ -26,7 +26,8 @@
 #include <map>
 #include <string>
 #include <cstddef>
-#include <mutex>
+
+namespace TR { class Monitor; }
 
 namespace OMR
 {
@@ -46,8 +47,6 @@ class CCData
 
       /** \typedef section_t Implementation detail. This type represents the table itself. It must behave like a pointer to an array of type data_t. */
       typedef std::unique_ptr<data_t[]> section_t;
-
-      typedef std::mutex mutex_t;
 
    public:
       /** \typedef index_t This type represents the indices defined in the public interface of this class. They must behave like integral types. */
@@ -208,7 +207,7 @@ class CCData
       const size_t      _capacity;
       size_t            _putIndex;
       map_t             _mappings;
-      mutable mutex_t   _lock;
+      TR::Monitor      *_lock;
       const bool        _releaseData;
    };
 

--- a/compiler/codegen/CCData.hpp
+++ b/compiler/codegen/CCData.hpp
@@ -22,7 +22,6 @@
 #ifndef OMR_CCDATA_INCL
 #define OMR_CCDATA_INCL
 
-#include <memory>
 #include <map>
 #include <string>
 #include <cstddef>
@@ -44,9 +43,6 @@ class CCData
    private:
       /** \typedef data_t Implementation detail. This type represents the units of the table. Typically bytes, but can be some other data type, as long as it can be default-constructed. */
       typedef uint8_t data_t;
-
-      /** \typedef section_t Implementation detail. This type represents the table itself. It must behave like a pointer to an array of type data_t. */
-      typedef std::unique_ptr<data_t[]> section_t;
 
    public:
       /** \typedef index_t This type represents the indices defined in the public interface of this class. They must behave like integral types. */
@@ -172,7 +168,7 @@ class CCData
 
        * @param[In] T The type of the value to get from the table. The type need not be TriviallyCopyable, since this function doesn't do any copying, but it probably should be for symmetry with the put() functions.
        * @param[In] index The index that refers to the value.
-       * @return A pointer to the value if the index refers to an existing value, nullptr otherwise.
+       * @return A pointer to the value if the index refers to an existing value, NULL otherwise.
        */
       template <typename T>
       T* get(const index_t index) const;
@@ -184,14 +180,9 @@ class CCData
        * @param[out] index Optional. A pointer to write the index to. This parameter is ignored unless this function returns true.
        * @return True if the given key maps to an index, false otherwise.
        */
-      bool find(const key_t key, index_t * const index = nullptr) const;
+      bool find(const key_t key, index_t * const index = NULL) const;
 
    private:
-      // Helper stuff used by the general (storage, sizeBytes) ctor.
-      typedef std::pair<data_t * const, const size_t> storage_and_size_pair_t;
-      CCData(const storage_and_size_pair_t storageAndSize);
-      static const storage_and_size_pair_t alignStorage(uint8_t * const storage, size_t sizeBytes);
-
       /**
        * @brief Checks if the given key maps to an index in this table and returns the index.
        *        This function is NOT synchronized (hence unsafe).
@@ -200,11 +191,11 @@ class CCData
        * @param[out] index Optional. A pointer to write the index to. This parameter is ignored unless this function returns true.
        * @return True if the given key maps to an index, false otherwise.
        */
-      bool find_unsafe(const key_t key, index_t * const index = nullptr) const;
+      bool find_unsafe(const key_t key, index_t * const index = NULL) const;
 
    private:
-      section_t         _data;         // Could be const were it not for the release() call in the dtor.
-      const size_t      _capacity;
+      data_t           *_data;
+      size_t            _capacity;
       size_t            _putIndex;
       map_t             _mappings;
       TR::Monitor      *_lock;

--- a/compiler/codegen/CCData_inlines.hpp
+++ b/compiler/codegen/CCData_inlines.hpp
@@ -40,18 +40,22 @@ CCData::key_t CCData::key(const T value)
 template <typename T>
 bool CCData::put(const T value, const key_t * const key, index_t &index)
    {
-#if __cpp_static_assert
-   static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
-#endif
+   // std::is_trivially_copyable is a C++11 type trait, but unfortunately there's no test macro for it.
+   // static_assert is also a C++11 feature, so testing for that would hopefully be enough, but unfortunately some old compilers have static_assert but not is_trivially_copyable,
+   // hence `#if __cpp_static_assert` is insufficient.
+//#if __cpp_static_assert
+//   static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
+//#endif
    return put(reinterpret_cast<const uint8_t *>(&value), sizeof(value), alignof(value), key, index);
    }
 
 template <typename T>
 bool CCData::get(const index_t index, T &value) const
    {
-#if __cpp_static_assert
-   static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
-#endif
+   // See above.
+//#if __cpp_static_assert
+//   static_assert(std::is_trivially_copyable<T>::value == true, "T must be trivially copyable.");
+//#endif
    return get(index, reinterpret_cast<uint8_t *>(&value), sizeof(value));
    }
 
@@ -61,9 +65,9 @@ T* CCData::get(const index_t index) const
    // Don't have to check if T is trivially_copyable here since we're not copying to/from a T.
    // The caller might, but it is then their responsibility to make sure.
    if (index >= _capacity)
-      return nullptr;
+      return NULL;
 
-   return reinterpret_cast<T *>(_data.get() + index);
+   return reinterpret_cast<T *>(_data + index);
    }
 
 }

--- a/fvtest/compilertest/CMakeLists.txt
+++ b/fvtest/compilertest/CMakeLists.txt
@@ -74,7 +74,6 @@ omr_add_executable(compilertest NOWARNINGS
 	tests/FooBarTest.cpp
 	tests/LimitFileTest.cpp
 	tests/LogFileTest.cpp
-	tests/CCDataTest.cpp
 	tests/OMRTestEnv.cpp
 	tests/OptionSetTest.cpp
 	tests/OpCodesTest.cpp
@@ -97,6 +96,14 @@ omr_add_executable(compilertest NOWARNINGS
 	tests/injectors/SelectOpIlInjector.cpp
 	tests/injectors/UnaryOpIlInjector.cpp
 )
+
+# MSVC and XL C/C++ have trouble with this file
+if (NOT OMR_TOOLCONFIG STREQUAL "msvc" AND NOT OMR_TOOLCONFIG STREQUAL "xlc")
+	target_sources(compilertest
+		PRIVATE
+			tests/CCDataTest.cpp
+	)
+endif()
 
 if(OMR_ARCH_X86)
 	target_sources(compilertest

--- a/fvtest/compilertest/tests/CCDataTest.cpp
+++ b/fvtest/compilertest/tests/CCDataTest.cpp
@@ -315,9 +315,9 @@ TYPED_TEST(CCDataTest, test_no_data_reservation_templated)
    // Make sure the index was written.
    EXPECT_NE(index, INVALID_INDEX);
    // Try to update the value via the key.
-   EXPECT_DEATH(table.put(nullptr, reservationSize, reservationAlignment, &key, index2), "");
-   // Make sure the index wasn't written.
-   EXPECT_EQ(index2, INVALID_INDEX);
+   EXPECT_TRUE(table.put(nullptr, reservationSize, reservationAlignment, &key, index2));
+   // Make sure the index was written.
+   EXPECT_EQ(index2, index);
 
    const TypeParam * const dataPtr = table.get<TypeParam>(index);
 
@@ -421,9 +421,9 @@ TYPED_TEST(CCDataTest, test_updating_templated)
    // Make sure the index was written.
    EXPECT_NE(index1, INVALID_INDEX);
    // Update the value via the key.
-   EXPECT_DEATH(table.put(data2, &key, index2), "");
-    // Make sure the index wasn't written.
-   EXPECT_EQ(index2, INVALID_INDEX);
+   EXPECT_TRUE(table.put(data2, &key, index2));
+   // Make sure the index was written.
+   EXPECT_EQ(index2, index1);
 
    TypeParam * const dataPtr = table.get<TypeParam>(index1);
 

--- a/fvtest/compilertest/tests/CCDataTest.cpp
+++ b/fvtest/compilertest/tests/CCDataTest.cpp
@@ -102,7 +102,7 @@ class GeneratedMethodInfo : public MethodInfo
 class TableTest : public OptTestDriver
    {
    public:
-      TableTest() : _caseValues(nullptr), _numCaseValues(0) {}
+      TableTest() : _caseValues(NULL), _numCaseValues(0) {}
       void setCaseValues(const int32_t * const caseValues, const size_t numCaseValues)
          {
          _caseValues = caseValues;
@@ -110,7 +110,7 @@ class TableTest : public OptTestDriver
          }
       virtual void invokeTests() override
          {
-         EXPECT_NE(_caseValues, nullptr);
+         EXPECT_TRUE(_caseValues != NULL);
          EXPECT_GT(_numCaseValues, 0);
          auto compiledMethod = getCompiledMethod<GeneratedMethodInfo::compiled_method_t>();
          for (auto i = 0; i < _numCaseValues; ++i)
@@ -219,9 +219,9 @@ TYPED_TEST(CCDataTest, test_basics_templated)
    const TypeParam * const dataPtr = table.get<TypeParam>(index);
 
    // Make sure the data was written.
-   EXPECT_NE(dataPtr, nullptr);
+   EXPECT_TRUE(dataPtr != NULL);
    // Make sure it was written to an aligned address.
-   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (alignof(data) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (OMR_ALIGNOF(data) - 1), 0);
    // Make sure it was written correctly.
    EXPECT_EQ(*dataPtr, data);
    // We should be able to find something with this key now.
@@ -244,7 +244,7 @@ TYPED_TEST(CCDataTest, test_basics_templated)
    EXPECT_EQ(index, find_index);
 
    // Make sure we can fill the table.
-   while (table.put(data, nullptr, index));
+   while (table.put(data, NULL, index));
    }
 
 TYPED_TEST(CCDataTest, test_arbitrary_data_templated)
@@ -261,16 +261,16 @@ TYPED_TEST(CCDataTest, test_arbitrary_data_templated)
    CCData::index_t index = INVALID_INDEX;
 
    // Put the data in the table, associate it with the key, retrieve the index.
-   EXPECT_TRUE(table.put(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data), alignof(data), &key, index));
+   EXPECT_TRUE(table.put(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data), OMR_ALIGNOF(data), &key, index));
    // Make sure the index was written.
    EXPECT_NE(index, INVALID_INDEX);
 
    const TypeParam * const dataPtr = table.get<TypeParam>(index);
 
    // Make sure the data was written.
-   EXPECT_NE(dataPtr, nullptr);
+   EXPECT_TRUE(dataPtr != NULL);
    // Make sure it was written to an aligned address.
-   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (alignof(data) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (OMR_ALIGNOF(data) - 1), 0);
    // Make sure it was written correctly.
    EXPECT_TRUE(std::equal(data, data + sizeof(data)/sizeof(data[0]), dataPtr));
    // We should be able to find something with this key now.
@@ -294,7 +294,7 @@ TYPED_TEST(CCDataTest, test_arbitrary_data_templated)
    EXPECT_EQ(index, find_index);
 
    // Make sure we can fill the table.
-   while (table.put(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data), alignof(data), nullptr, index));
+   while (table.put(reinterpret_cast<const uint8_t *>(&data[0]), sizeof(data), OMR_ALIGNOF(data), NULL, index));
    }
 
 TYPED_TEST(CCDataTest, test_no_data_reservation_templated)
@@ -311,18 +311,18 @@ TYPED_TEST(CCDataTest, test_no_data_reservation_templated)
    CCData::index_t index2 = INVALID_INDEX;
 
    // Reserve space in the table, associate it with the key, retrieve the index.
-   EXPECT_TRUE(table.put(nullptr, reservationSize, reservationAlignment, &key, index));
+   EXPECT_TRUE(table.put(NULL, reservationSize, reservationAlignment, &key, index));
    // Make sure the index was written.
    EXPECT_NE(index, INVALID_INDEX);
    // Try to update the value via the key.
-   EXPECT_TRUE(table.put(nullptr, reservationSize, reservationAlignment, &key, index2));
+   EXPECT_TRUE(table.put(NULL, reservationSize, reservationAlignment, &key, index2));
    // Make sure the index was written.
    EXPECT_EQ(index2, index);
 
    const TypeParam * const dataPtr = table.get<TypeParam>(index);
 
    // Make sure the reservation was done.
-   EXPECT_NE(dataPtr, nullptr);
+   EXPECT_TRUE(dataPtr != NULL);
    // Make sure we got an aligned address.
    EXPECT_EQ(reinterpret_cast<size_t>(dataPtr) & (reservationAlignment - 1), 0);
    // We should be able to find something with this key now.
@@ -336,7 +336,7 @@ TYPED_TEST(CCDataTest, test_no_data_reservation_templated)
    EXPECT_EQ(index, find_index);
 
    // Make sure we can fill the table.
-   while (table.put(nullptr, reservationSize, reservationAlignment, nullptr, index));
+   while (table.put(NULL, reservationSize, reservationAlignment, NULL, index));
    }
 
 #define STRINGIFY(x) #x
@@ -377,7 +377,7 @@ TYPED_TEST(CCDataTest, test_error_conditions_templated)
       CCData::index_t   index = INVALID_INDEX;
 
       // Shouldn't be able to put.
-      EXPECT_FALSE(zeroTable.put(data, nullptr, index));
+      EXPECT_FALSE(zeroTable.put(data, NULL, index));
       // Make sure the index didn't change.
       EXPECT_EQ(index, INVALID_INDEX);
       }
@@ -391,7 +391,7 @@ TYPED_TEST(CCDataTest, test_error_conditions_templated)
 
       int count = 0;
 
-      while (smallTable.put(data, nullptr, curIndex))
+      while (smallTable.put(data, NULL, curIndex))
          {
          // Make sure the index changed.
          EXPECT_NE(curIndex, lastIndex);
@@ -428,7 +428,7 @@ TYPED_TEST(CCDataTest, test_updating_templated)
    TypeParam * const dataPtr = table.get<TypeParam>(index1);
 
    // Make sure the data was written.
-   EXPECT_NE(dataPtr, nullptr);
+   EXPECT_TRUE(dataPtr != NULL);
    // Make sure it wasn't updated.
    EXPECT_EQ(*dataPtr, data1);
    // Change the value via a pointer.
@@ -543,21 +543,21 @@ TEST(AllTypesCCDataTest, test_basics)
    const double * const ptr_doubleA = table.get<const double>(doubleAIndex);
    const double * const ptr_doubleB = table.get<const double>(doubleBIndex);
 
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_classAptr) & (alignof(*ptr_classAptr) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_classBptr) & (alignof(*ptr_classBptr) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_funcAptr) & (alignof(*ptr_funcAptr) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_funcBptr) & (alignof(*ptr_funcBptr) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_intA) & (alignof(*ptr_intA) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_intB) & (alignof(*ptr_intB) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_shortA) & (alignof(*ptr_shortA) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_shortB) & (alignof(*ptr_shortB) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_floatA) & (alignof(*ptr_floatA) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_floatB) & (alignof(*ptr_floatB) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_doubleA) & (alignof(*ptr_doubleA) - 1), 0);
-   EXPECT_EQ(reinterpret_cast<size_t>(ptr_doubleB) & (alignof(*ptr_doubleB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_classAptr) & (OMR_ALIGNOF(*ptr_classAptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_classBptr) & (OMR_ALIGNOF(*ptr_classBptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_funcAptr) & (OMR_ALIGNOF(*ptr_funcAptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_funcBptr) & (OMR_ALIGNOF(*ptr_funcBptr) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_intA) & (OMR_ALIGNOF(*ptr_intA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_intB) & (OMR_ALIGNOF(*ptr_intB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_shortA) & (OMR_ALIGNOF(*ptr_shortA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_shortB) & (OMR_ALIGNOF(*ptr_shortB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_floatA) & (OMR_ALIGNOF(*ptr_floatA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_floatB) & (OMR_ALIGNOF(*ptr_floatB) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_doubleA) & (OMR_ALIGNOF(*ptr_doubleA) - 1), 0);
+   EXPECT_EQ(reinterpret_cast<size_t>(ptr_doubleB) & (OMR_ALIGNOF(*ptr_doubleB) - 1), 0);
 
-   void     *out_classAptr = nullptr, *out_classBptr = nullptr;
-   void     *out_funcAptr = nullptr, *out_funcBptr = nullptr;
+   void     *out_classAptr = NULL, *out_classBptr = NULL;
+   void     *out_funcAptr = NULL, *out_funcBptr = NULL;
    int      out_intA = ~intA, out_intB = ~intB;
    short    out_shortA = ~shortA, out_shortB = ~shortB;
    float    out_floatA = -floatA, out_floatB = -floatB;

--- a/fvtest/coretest/TestBytes.cpp
+++ b/fvtest/coretest/TestBytes.cpp
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
  *******************************************************************************/
 
+#include <omrcomp.h>
 #include <OMR/Bytes.hpp>
 #include <gtest/gtest.h>
 
@@ -187,7 +188,7 @@ TEST(TestBytes, AlignMaximumSizeFor16byteAlignment)
 TEST(TestBytes, AlignPointers)
 {
 	const size_t size = sizeof(void*);
-	const size_t alignment = alignof(void*);
+	const size_t alignment = OMR_ALIGNOF(void*);
 	const size_t totalSpace = size * 3 - 1;
 	char buffer[totalSpace] = {0};
 	void * const lastValidAddress = &buffer[totalSpace - size];

--- a/fvtest/coretest/TestBytes.cpp
+++ b/fvtest/coretest/TestBytes.cpp
@@ -184,4 +184,49 @@ TEST(TestBytes, AlignMaximumSizeFor16byteAlignment)
 	EXPECT_EQ(std::numeric_limits<size_t>::max(), align(std::numeric_limits<size_t>::max(), 1));
 }
 
+TEST(TestBytes, AlignPointers)
+{
+	const size_t size = sizeof(void*);
+	const size_t alignment = alignof(void*);
+	const size_t totalSpace = size * 3 - 1;
+	char buffer[totalSpace] = {0};
+	void * const lastValidAddress = &buffer[totalSpace - size];
+
+	for (size_t i = 0; i < totalSpace; i++) {
+		size_t space = totalSpace - i;
+		void *ptr = &buffer[i];
+		const size_t initialSpace = space;
+		void * const initialPtr = ptr;
+		uintptr_t ptrValue = reinterpret_cast<uintptr_t>(ptr);
+
+		const void *alignedPtr = OMR::align(alignment, size, ptr, space);
+		const uintptr_t alignedPtrValue = reinterpret_cast<uintptr_t>(alignedPtr);
+
+		// Whatever was returned must be aligned.
+		EXPECT_EQ(alignedPtrValue & (alignment - 1), 0);
+
+		if (alignedPtr != NULL) {
+			// The passed-in ptr reference must be updated to match the returned pointer.
+			EXPECT_EQ(ptr, alignedPtr);
+			// The returned pointer must be aligned in the expected manner.
+			const void *expectedPtr = reinterpret_cast<void *>((ptrValue + (alignment - 1)) & ~(alignment - 1));
+			EXPECT_EQ(alignedPtr, expectedPtr);
+			// The passed-in space reference must be updated to subtract the bytes lost to obtain the desired alignment.
+			const size_t expectedAdjustment = (alignment - (ptrValue & (alignment - 1))) % alignment;
+			EXPECT_EQ(space, initialSpace - expectedAdjustment);
+			// The data must not overflow the buffer.
+			EXPECT_LE(alignedPtr, lastValidAddress);
+		}
+		else {
+			// The passed-in ptr reference must not have been updated.
+			EXPECT_EQ(ptr, initialPtr);
+			// The passed-in space reference must not have been updated.
+			EXPECT_EQ(space, initialSpace);
+			// The returned pointer must be NULL because we don't have any space left to make the adjustment.
+			const size_t alignmentAdjustment = (alignment - (ptrValue & (alignment - 1))) % alignment;
+			EXPECT_LT(initialSpace, size + alignmentAdjustment);
+		}
+	}
+}
+
 }  // namespace OMR

--- a/include_core/OMR/Bytes.hpp
+++ b/include_core/OMR/Bytes.hpp
@@ -108,6 +108,28 @@ align(size_t size, size_t alignment)
 	return alignNoCheck(size, alignment);
 }
 
+/// Returns an aligned pointer.
+///
+/// This function has the same semantics as C++11's std::align() and
+/// exists to support old compilers that don't provide it.
+inline void*
+align(size_t alignment, size_t size, void* &ptr, size_t &space)
+{
+	if (size > space) {
+		return NULL;
+	}
+	uintptr_t p = reinterpret_cast<uintptr_t>(ptr);
+	uintptr_t alignedP = (p + (alignment - 1)) & ~(alignment - 1);
+	uintptr_t adjustment = alignedP - p;
+	if (adjustment > (space - size)) {
+		return NULL;
+	}
+	space -= adjustment;
+	void *alignedPtr = reinterpret_cast<void*>(alignedP);
+	ptr = alignedPtr;
+	return alignedPtr;
+}
+
 } // namespace OMR
 
 #endif // OMR_BYTES_HPP_

--- a/include_core/omrcomp.h
+++ b/include_core/omrcomp.h
@@ -601,4 +601,12 @@ typedef struct U_128 {
 #define OMR_LOG_POINTER_SIZE 2
 #endif /* defined(OMR_ENV_DATA64) */
 
+#if defined(_MSC_VER) && (1900 > _MSC_VER) /* MSVC versions prior to Visual Studio 2015 (14.0) */
+#define OMR_ALIGNOF(x) __alignof(x)
+#elif defined(__IBMC__) || defined(__IBMCPP__) /* XL C/C++ versions prior to xlclang/xlclang++ */
+#define OMR_ALIGNOF(x) __alignof__(x)
+#else /* All other compilers that support C11 and C++11 */
+#define OMR_ALIGNOF(x) alignof(x)
+#endif /* defined(_MSC_VER) && (1900 > _MSC_VER) */
+
 #endif /* OMRCOMP_H */


### PR DESCRIPTION
Some of the CCData support in the snapshot branch was recently merged into OMR by https://github.com/eclipse/omr/pull/5634. In the process changes had to be made to get CCData building on the various other platforms that we aren't concerned with on this branch.

This PR represents those additional changes that are now in OMR master.

Fixes #89