### PR TITLE
(0.24.0) Remove newline in omrsysinfo_get_processor_feature_string

### DIFF
--- a/include_core/omrport.h
+++ b/include_core/omrport.h
@@ -1798,7 +1798,7 @@ typedef struct OMRPortLibrary {
 	/** see @ref omrsysinfo.c::omrsysinfo_get_processor_feature_name "omrsysinfo_get_processor_feature_name"*/
 	const char  *( *sysinfo_get_processor_feature_name)(struct OMRPortLibrary *portLibrary, uint32_t feature) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_processor_feature_string "omrsysinfo_get_processor_feature_string"*/
-	void ( *sysinfo_get_processor_feature_string)(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, char * buffer, const size_t length) ;
+	intptr_t ( *sysinfo_get_processor_feature_string)(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, char * buffer, const size_t length) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_OS_type "omrsysinfo_get_OS_type"*/
 	const char *(*sysinfo_get_OS_type)(struct OMRPortLibrary *portLibrary) ;
 	/** see @ref omrsysinfo.c::omrsysinfo_get_executable_name "omrsysinfo_get_executable_name"*/

--- a/port/common/omrsysinfo.c
+++ b/port/common/omrsysinfo.c
@@ -171,8 +171,10 @@ omrsysinfo_get_processor_feature_name(struct OMRPortLibrary *portLibrary, uint32
  * @param[in] desc The struct that contains the list of processor features to be converted to string.
  * @param[out] buffer The processor feature output string.
  * @param[in] length The size of the buffer in number of bytes.
+ *
+ * @return 0 on success, -1 if output string size exceeds input length.
  */
-void
+intptr_t
 omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, char *buffer, const size_t length)
 {
 }

--- a/port/omrportpriv.h
+++ b/port/omrportpriv.h
@@ -579,7 +579,7 @@ extern J9_CFUNC intptr_t
 omrsysinfo_processor_set_feature(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, uint32_t feature, BOOLEAN enable);
 extern J9_CFUNC const char *
 omrsysinfo_get_processor_feature_name(struct OMRPortLibrary *portLibrary, uint32_t feature);
-extern J9_CFUNC void
+extern J9_CFUNC intptr_t
 omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, char * buffer, const size_t length);
 extern J9_CFUNC const char *
 omrsysinfo_get_OS_version(struct OMRPortLibrary *portLibrary);

--- a/port/unix/omrsysinfo.c
+++ b/port/unix/omrsysinfo.c
@@ -718,16 +718,20 @@ omrsysinfo_get_processor_feature_name(struct OMRPortLibrary *portLibrary, uint32
  * @param[in] desc The struct that contains the list of processor features to be converted to string.
  * @param[out] buffer The processor feature output string.
  * @param[in] length The size of the buffer in number of bytes.
+ *
+ * @return 0 on success, -1 if output string size exceeds input length.
  */
-void
+intptr_t
 omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRProcessorDesc *desc, char * buffer, const size_t length)
 {
 	BOOLEAN start = TRUE;
 	size_t i = 0;
 	size_t j = 0;
 	size_t numberOfBits = 0;
+	size_t bufferLength = 0;
 
 	memset(buffer, 0, length * sizeof(char));
+
 	for (i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++) {
 		numberOfBits = CHAR_BIT * sizeof(desc->features[i]);
 		for (j = 0; j < numberOfBits; j++) {
@@ -735,18 +739,26 @@ omrsysinfo_get_processor_feature_string(struct OMRPortLibrary *portLibrary, OMRP
 			if (desc->features[i] & (1 << j)) {
 				uint32_t feature = (uint32_t)(i * numberOfBits + j);
 				const char * featureName = omrsysinfo_get_processor_feature_name(portLibrary, feature);
+				size_t featureLength = strlen(featureName);
 				
 				if (start == FALSE) {
-					strncat(buffer, " ", length - strlen(buffer) - 1);
+					strncat(buffer, " ", length - bufferLength - 1);
+					bufferLength += 1;
 				}
 				else {
 					start = FALSE;
 				}
-				strncat(buffer, featureName, length - strlen(buffer) - 1);
+
+				if (length - bufferLength - 1 < featureLength) {
+					return -1;
+				}
+
+				strncat(buffer, featureName, length - bufferLength - 1);
+				bufferLength += featureLength;
 		    }
 		}
 	}
-	strncat(buffer, "\n", length - strlen(buffer) - 1);
+	return 0;
 }
 
 #if (defined(AIXPPC) || defined(S390) || defined(J9ZOS390))


### PR DESCRIPTION
Issue: https://github.com/eclipse/openj9/issues/11184

Port https://github.com/eclipse/omr/pull/5707 for the 0.24.0 release.

Signed-off-by: Harry Yu <harryyu1994@gmail.com>