### PR TITLE
Snapshot+restore lock persistence api

### DIFF
--- a/include_core/thread_api.h
+++ b/include_core/thread_api.h
@@ -533,6 +533,41 @@ omrthread_global(char *name);
 omrthread_monitor_t
 omrthread_global_monitor(void);
 
+/**
+ * Return monitor that thread is currently waiting to acquire. 
+ * If thread is not waiting on a monitor return null.
+ * @param thread
+ * @return omrthread_monitor_t
+ */
+omrthread_monitor_t
+omrthread_waiting_to_acquire(omrthread_t thread);
+
+/**
+ * Return true if monitor is currently acquired.
+ * @param monitor
+ * @return BOOLEAN
+ */
+BOOLEAN
+omrthread_monitor_is_acquired(omrthread_monitor_t monitor);
+
+/**
+ * Monitor may be acquired multiple times by the current owner.
+ * Return number of times it has been acquired. Zero means
+ * the monitor is not acquired.
+ * @param monitor
+ * @return uint32_t
+ */
+uint32_t
+omrthread_monitor_getNumOfTimesAcquired(omrthread_monitor_t monitor);
+
+/**
+ * Return thread that currently owns the monitor. Null 
+ * will be returned if monitor is not owned.
+ * @param monitor
+ * @return omrthread_t
+ */
+omrthread_t
+omrthread_monitor_getCurrentOwner(omrthread_monitor_t monitor);
 
 /**
 * @brief

--- a/thread/common/omrthread.c
+++ b/thread/common/omrthread.c
@@ -1219,6 +1219,25 @@ omrthread_global_monitor(void)
 	return lib->globalMonitor;
 }
 
+omrthread_monitor_t
+omrthread_waiting_to_acquire(omrthread_t thread) {
+	return thread->monitor;
+}
+
+BOOLEAN
+omrthread_monitor_is_acquired(omrthread_monitor_t monitor) {
+	return (monitor->count > 0);
+}
+
+uint32_t
+omrthread_monitor_getNumOfTimesAcquired(omrthread_monitor_t monitor) {
+	return monitor->count;
+}
+
+omrthread_t
+omrthread_monitor_getCurrentOwner(omrthread_monitor_t monitor) {
+	return monitor->owner;
+}
 
 /*
  * Threads
@@ -1839,7 +1858,7 @@ dontreturn:
 /**
  * Create a new OS thread and attach it to the library.
  *
- * @param[out] handle
+ * @param[out] handle Location where the new omrthread_t should be returned, if successfully created. May be NULL.
  * @param[in] attr attr must not be modified by this function.
  * @param[in] suspend Non-zero if the thread should suspend before entering entrypoint,
  * zero to allow the thread to run freely.
@@ -5906,4 +5925,3 @@ j9thread_tls_get(omrthread_t thread, omrthread_tls_key_t key)
 {
 	return omrthread_tls_get(thread, key);
 }
-

--- a/thread/exports.cmake
+++ b/thread/exports.cmake
@@ -33,6 +33,10 @@ omr_add_exports(j9thr_obj
 	omrthread_abort
 	omrthread_attach
 	omrthread_attach_ex
+	omrthread_waiting_to_acquire
+	omrthread_monitor_is_acquired
+	omrthread_monitor_getNumOfTimesAcquired
+	omrthread_monitor_getCurrentOwner
 	omrthread_create
 	omrthread_create_ex
 	omrthread_cancel

--- a/thread/thread_include.mk
+++ b/thread/thread_include.mk
@@ -141,6 +141,10 @@ define WRITE_COMMON_THREAD_EXPORTS
 @echo omrthread_abort >>$@
 @echo omrthread_attach >>$@
 @echo omrthread_attach_ex >>$@
+@echo omrthread_waiting_to_acquire >>$@
+@echo omrthread_monitor_is_acquired >>$@
+@echo omrthread_monitor_getNumOfTimesAcquired >>$@
+@echo omrthread_monitor_getCurrentOwner >>$@
 @echo omrthread_create >>$@
 @echo omrthread_create_ex >>$@
 @echo omrthread_cancel >>$@


### PR DESCRIPTION
Thread api additions to expose system monitor information to OpenJ9 snapshot+restore

API to support https://github.com/eclipse/openj9/pull/11414 (this openj9-omr pr should be merged first)

Signed-off-by: Theresa Mammarella <tmammare@redhat.com>