### PR TITLE
(0.24.0) Filter "C." in the list of locales using language "en"

### DIFF
--- a/port/unix/j9nlshelpers.c
+++ b/port/unix/j9nlshelpers.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2019 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -117,7 +117,12 @@ nls_determine_locale(struct OMRPortLibrary *portLibrary)
 	}
 #endif /* defined (J9ZOS390) */
 #endif  /* defined(LINUX) || defined(OSX) */
-	if ((NULL != lang) && strcmp(lang, "POSIX") && strcmp(lang, "C") && strcmp(lang, "UTF-8")) {
+	if ((NULL != lang)
+		&& (0 != strcmp(lang, "POSIX"))
+		&& (0 != strcmp(lang, "C"))
+		&& (0 != strncmp(lang, "C.", 2))
+		&& (0 != strcmp(lang, "UTF-8"))
+	) {
 		if ((NULL != lang) && ((langlen = strlen(lang)) >= 2)) {
 			/* copy the language, stopping at '_'
 			 * CMVC 145188 - language locale must be lowercase


### PR DESCRIPTION
Locales such as C.UTF-8 must set the language to "en" and not "c.u".

Issue https://github.com/eclipse/openj9/issues/11620

Closes https://github.com/eclipse/openj9-omr/issues/98