### PR TITLE
(0.26.0) Fix memory leak from omrsysinfo_get_OS_version()

### DIFF
--- a/port/win32/omrsysinfo.c
+++ b/port/win32/omrsysinfo.c
@@ -654,6 +654,7 @@ omrsysinfo_get_OS_version(struct OMRPortLibrary *portLibrary)
 			WideCharToMultiByte(OS_ENCODING_CODE_PAGE, OS_ENCODING_WC_FLAGS, versionInfo.szCSDVersion, -1, &buffer[position], (int)(len - position - 1), NULL, NULL);
 		}
 		PPG_si_osVersion = buffer;
+		PPG_si_osVersionOnHeap = buffer;
 	}
 	return PPG_si_osVersion;
 }
@@ -1024,14 +1025,11 @@ void
 omrsysinfo_shutdown(struct OMRPortLibrary *portLibrary)
 {
 	if (NULL != portLibrary->portGlobals) {
-#if defined(_WIN32_WINNT_WINBLUE) && (_WIN32_WINNT_MAXVER >= _WIN32_WINNT_WINBLUE)
-		PPG_si_osVersion = NULL;
-#else
-		if (PPG_si_osVersion) {
-			portLibrary->mem_free_memory(portLibrary, PPG_si_osVersion);
-			PPG_si_osVersion = NULL;
+		if (NULL != PPG_si_osVersionOnHeap) {
+			portLibrary->mem_free_memory(portLibrary, PPG_si_osVersionOnHeap);
+			PPG_si_osVersionOnHeap = NULL;
 		}
-#endif
+		PPG_si_osVersion = NULL;
 
 		if (NULL != PPG_si_osTypeOnHeap) {
 			portLibrary->mem_free_memory(portLibrary, PPG_si_osTypeOnHeap);

--- a/port/win32_include/omrportpg.h
+++ b/port/win32_include/omrportpg.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 1991, 2015 IBM Corp. and others
+ * Copyright (c) 1991, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -132,6 +132,7 @@ typedef struct OMRPortPlatformGlobals {
 	char *si_osType;
 	char *si_osTypeOnHeap;
 	char *si_osVersion;
+	char *si_osVersionOnHeap;
 	uint64_t time_hiresClockFrequency;
 	void *tty_consoleEventBuffer;  /* windows.h cannot be included here and it has a complex definition so use void * in place of INPUT_RECORD* */
 	omrthread_monitor_t tty_consoleBufferMonitor;
@@ -169,6 +170,7 @@ typedef struct OMRPortPlatformGlobals {
 #define PPG_si_osType (portLibrary->portGlobals->platformGlobals.si_osType)
 #define PPG_si_osTypeOnHeap (portLibrary->portGlobals->platformGlobals.si_osTypeOnHeap)
 #define PPG_si_osVersion (portLibrary->portGlobals->platformGlobals.si_osVersion)
+#define PPG_si_osVersionOnHeap (portLibrary->portGlobals->platformGlobals.si_osVersionOnHeap)
 #define PPG_time_hiresClockFrequency (portLibrary->portGlobals->platformGlobals.time_hiresClockFrequency)
 #define PPG_tty_consoleEventBuffer (portLibrary->portGlobals->platformGlobals.tty_consoleEventBuffer)
 #define PPG_tty_consoleBufferMonitor (portLibrary->portGlobals->platformGlobals.tty_consoleBufferMonitor)


### PR DESCRIPTION
Cherry pick https://github.com/eclipse/omr/pull/5878 for the 0.26.0 release.